### PR TITLE
Add ARIA in HTML specification resource

### DIFF
--- a/cortex_browser/resources/aria-in-html.html
+++ b/cortex_browser/resources/aria-in-html.html
@@ -1,0 +1,5907 @@
+<!DOCTYPE html><html lang="en-us"><head>
+<meta charset="utf-8">
+<meta name="generator" content="ReSpec 35.4.3">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+span.example-title{text-transform:none}
+:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+div.illegal-example{color:red}
+div.illegal-example p{color:#000}
+aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+</style>
+<style>
+.issue-label{text-transform:initial}
+.warning>p:first-child{margin-top:0}
+.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+span.warning{padding:.1em .5em .15em}
+.issue.closed span.issue-number{text-decoration:line-through}
+.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
+.warning{border-color:#f11;border-color:var(--warning-border,#f11);border-width:.2em;border-style:solid;background:#fbe9e9;background:var(--warning-bg,#fbe9e9);color:#000;color:var(--text,#000)}
+.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+li.task-list-item{list-style:none}
+input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;background:var(--indextable-hover-bg,#fff);color:#000;color:var(--text,#000);box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);box-shadow:0 1em 3em -.4em var(--tocsidebar-shadow,rgba(0,0,0,.3)),0 0 1px 1px var(--tocsidebar-shadow,rgba(0,0,0,.05));border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;border-bottom-color:var(--indextable-hover-bg,#fff);top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1;border-bottom-color:var(--indextable-hover-bg,#a2a9b1)}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;color:var(--text,#000);margin-top:.25em}
+.dfn-panel ul a[href]{color:#333;color:var(--text,#333)}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+    
+    
+<title>ARIA in HTML</title>
+    
+    
+    
+<link rel="stylesheet" href="makeup.css">
+  
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
+}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+}
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:italic}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+aside.example .marker>a.self-link{color:inherit}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+:is(h2,h3)+a.self-link{top:-.2em}
+:is(h4,h5,h6)+a.self-link::before{color:#000}
+@media (max-width:767px){
+dd{margin-left:0}
+}
+@media print{
+.removeOnSave{display:none}
+}
+</style>
+<meta name="color-scheme" content="light">
+<meta name="revision" content="6c2324007f3485e2b32959044ce253c5fc697f79">
+<meta name="description" content="This specification defines the authoring rules (author conformance requirements) for the use
+        of Accessible Rich Internet Applications (WAI-ARIA) 1.2 and Digital Publishing WAI-ARIA Module 1.0 attributes on [HTML] elements.
+        This specification's primary objective is to define requirements for use
+        with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors
+        in their development of web content, including custom interfaces and widgets, which make use of ARIA to
+        complement or extend the features of the host language [HTML].">
+<link rel="canonical" href="https://www.w3.org/TR/html-aria/">
+<style>
+.hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
+@media (prefers-color-scheme:dark){
+.hljs{--base:#282c34;--mono-1:#abb2bf;--mono-2:#818896;--mono-3:#5c6370;--hue-1:#56b6c2;--hue-2:#61aeee;--hue-3:#c678dd;--hue-4:#98c379;--hue-5:#e06c75;--hue-5-2:#be5046;--hue-6:#d19a66;--hue-6-2:#e6c07b}
+}
+.hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;color:var(--mono-1,#383a42);background:#fafafa;background:var(--base,#fafafa)}
+.hljs-comment,.hljs-quote{color:#717277;color:var(--mono-3,#717277);font-style:italic}
+.hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4;color:var(--hue-3,#a626a4)}
+.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;color:var(--hue-5,#ca4706);font-weight:700}
+.hljs-literal{color:#0b76c5;color:var(--hue-1,#0b76c5)}
+.hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c;color:var(--hue-4,#42803c)}
+.hljs-built_in,.hljs-class .hljs-title{color:#9a6a01;color:var(--hue-6-2,#9a6a01)}
+.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801;color:var(--hue-6,#986801)}
+.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3;color:var(--hue-2,#336ae3)}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{text-decoration:underline}
+</style>
+<style>
+var:hover{text-decoration:underline;cursor:pointer}
+var.respec-hl{color:var(--color,#000);background-color:var(--bg-color);box-shadow:0 0 0 2px var(--bg-color)}
+@media (prefers-color-scheme:dark){
+var.respec-hl{filter:saturate(.9) brightness(.9)}
+}
+var.respec-hl-c1{--bg-color:#f4d200}
+var.respec-hl-c2{--bg-color:#ff87a2}
+var.respec-hl-c3{--bg-color:#96e885}
+var.respec-hl-c4{--bg-color:#3eeed2}
+var.respec-hl-c5{--bg-color:#eacfb6}
+var.respec-hl-c6{--bg-color:#82ddff}
+var.respec-hl-c7{--bg-color:#ffbcf2}
+@media print{
+var.respec-hl{background:0 0;color:#000;box-shadow:unset}
+}
+</style>
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#222}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#222;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+</style>
+<script id="initialUserConfig" type="application/json">{
+  "editors": [
+    {
+      "name": "Scott O'Hara",
+      "company": "Microsoft",
+      "companyURL": "https://www.microsoft.com/",
+      "w3cid": "103856"
+    },
+    {
+      "name": "Patrick H. Lauke",
+      "company": "TetraLogical",
+      "companyURL": "https://tetralogical.com/",
+      "w3cid": "35129"
+    }
+  ],
+  "previousMaturity": "REC",
+  "perEnd": "2022-09-01",
+  "previousPublishDate": "2025-07-23",
+  "implementationReportURI": "https://w3c.github.io/html-aria/results/implementation-results.html",
+  "github": "w3c/html-aria/",
+  "maxTocLevel": 2,
+  "shortName": "html-aria",
+  "specStatus": "REC",
+  "revisionTypes": [
+    "addition",
+    "correction"
+  ],
+  "group": "webapps",
+  "wgPublicList": "public-webapps",
+  "xref": true,
+  "errata": "https://github.com/w3c/html-aria/issues/new/",
+  "gitRevision": "6c2324007f3485e2b32959044ce253c5fc697f79",
+  "publishDate": "2025-08-05",
+  "publishISODate": "2025-08-05T00:00:00.000Z",
+  "generatedSubtitle": "W3C Recommendation 05 August 2025"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-REC"></head>
+  <body data-cite="HTML WAI-ARIA INFRA" class="h-entry"><div class="head">
+    <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
+  </a></p>
+    <h1 id="title" class="title">ARIA in HTML</h1> 
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#REC">W3C Recommendation</a> <time class="dt-published" datetime="2025-08-05">05 August 2025</time></p>
+    <details open="">
+      <summary>More details about this document</summary>
+      <dl>
+        <dt>This version:</dt><dd>
+                <a class="u-url" href="https://www.w3.org/TR/2025/REC-html-aria-20250805/">https://www.w3.org/TR/2025/REC-html-aria-20250805/</a>
+              </dd>
+        <dt>Latest published version:</dt><dd>
+                <a href="https://www.w3.org/TR/html-aria/">https://www.w3.org/TR/html-aria/</a>
+              </dd>
+        <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/html-aria/">https://w3c.github.io/html-aria/</a></dd>
+        <dt>History:</dt><dd>
+                    <a href="https://www.w3.org/standards/history/html-aria/">https://www.w3.org/standards/history/html-aria/</a>
+                  </dd><dd>
+                    <a href="https://github.com/w3c/html-aria/commits/">Commit history</a>
+                  </dd>
+        
+        <dt>Implementation report:</dt><dd>
+                <a href="https://w3c.github.io/html-aria/results/implementation-results.html">https://w3c.github.io/html-aria/results/implementation-results.html</a>
+              </dd>
+        
+        
+        
+        <dt>Editors:</dt><dd class="editor p-author h-card vcard" data-editor-id="103856">
+    <span class="p-name fn">Scott O'Hara</span> (<a class="p-org org h-org" href="https://www.microsoft.com/">Microsoft</a>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="35129">
+    <span class="p-name fn">Patrick H. Lauke</span> (<a class="p-org org h-org" href="https://tetralogical.com/">TetraLogical</a>)
+  </dd>
+        <dt>
+                Former editor:
+              </dt><dd class="editor p-author h-card vcard" data-editor-id="35007">
+    <span class="p-name fn">Steve Faulkner</span> (<a class="p-org org h-org" href="https://www.tpgi.com/">TPGi</a>) -  Until <time datetime="2023-04-28">28 April 2023</time>
+  </dd>
+        
+        <dt>Feedback:</dt><dd>
+        <a href="https://github.com/w3c/html-aria/">GitHub w3c/html-aria</a>
+        (<a href="https://github.com/w3c/html-aria/pulls/">pull requests</a>,
+        <a href="https://github.com/w3c/html-aria/issues/new/choose">new issue</a>,
+        <a href="https://github.com/w3c/html-aria/issues/">open issues</a>)
+      </dd><dd><a href="mailto:public-webapps@w3.org?subject=%5Bhtml-aria%5D%20YOUR%20TOPIC%20HERE">public-webapps@w3.org</a> with subject line <kbd>[html-aria] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-webapps">archives</a>)</dd>
+        <dt>Errata:</dt><dd><a href="https://github.com/w3c/html-aria/issues/new/">Errata exists</a>.</dd>
+        
+      </dl>
+    </details>
+    <p>
+          See also
+          <a href="https://www.w3.org/Translations/?technology=html-aria">
+            <strong>translations</strong></a>.
+        </p>
+    
+    <p class="copyright">
+    <a href="https://www.w3.org/policies/#copyright">Copyright</a>
+    ©
+    2025
+    
+    <a href="https://www.w3.org/">World Wide Web Consortium</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+    <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and
+    <a rel="license" href="https://www.w3.org/copyright/software-license-2023/" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
+  </p>
+    <hr title="Separator for header">
+  </div>
+    <section id="abstract" class="introductory"><h2>Abstract</h2>
+      <p>
+        This specification defines the authoring rules (author conformance requirements) for the use
+        of <cite><a data-matched-text="[[[wai-aria-1.2]]]" href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> and <cite><a data-matched-text="[[[dpub-aria-1.0]]]" href="https://www.w3.org/TR/dpub-aria-1.0/">Digital Publishing WAI-ARIA Module 1.0</a></cite> attributes on [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] elements.
+        This specification's primary objective is to define requirements for use
+        with conformance checking tools used by authors (i.e., web developers). These requirements will aid authors
+        in their development of web content, including custom interfaces and widgets, which make use of ARIA to
+        complement or extend the features of the host language [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>].
+      </p>
+    </section>
+    <section id="sotd" class="updateable-rec introductory"><h2>Status of This Document</h2><p><em>This section describes the status of this
+      document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr>
+      publications and the latest revision of this technical report can be found
+      in the
+      <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> standards and drafts index</a>.</em></p>
+      <p>
+        ARIA in HTML is an [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] specification module. Any HTML features, conformance requirements, or terms that this specification
+        module makes reference to, but does not explicitly define, are defined by the <cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML Standard</a></cite>.
+      </p>
+      <p>
+        Since this specification become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation on 09 December 2021,
+        the following substantive additions and/or corrections have been proposed:
+      </p>
+      <ul>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/556">23 July 2025 - Addition:</a>
+          Update the <a href="#el-label"><code>label</code></a> element to allow <code>role</code> and <code>aria-*</code> attributes
+          to be specified when the element is not associated with a labelable element.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/528">23 July 2025 - Addition:</a>
+          Add the <a href="#el-selectedcontent"><code>selectedcontent</code></a> element and provide updated
+          allowances for the <a href="#el-button"><code>button</code></a> element when it is used in the context
+          of a customized <code>select</code> element.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/550">23 July 2025 - Correction:</a>
+          Clarify that the <a href="#el-html"><code>html</code></a> element is a <code>generic</code> element, and that
+          neither the <code>document</code> or <code>generic</code> roles are recommended to be used on the element.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/525">23 December 2024 - Addition:</a>
+          Update the <a href="#el-img"><code>img</code></a> element to allow the <code>math</code> role.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/533">13 December 2024 - Addition:</a>
+          Update to include the <code>image</code> role as preferred synonym to the <code>img</code> role.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/507">13 December 2024 - Addition:</a>
+          Clarify the allowance for <code>aria-hidden</code> when used with the <code>hidden</code> attribute.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/489">4 October 2023 - Addition:</a>
+          Update the button element and input type=button,image,reset,submit elements to allow the <code>separator</code> role.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/453">3 October 2023 - Correction:</a>
+          Update the <a href="#el-img"><code>img</code></a> element allowances to be based on if the element has an accessible name or not.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/462">21 August 2023 - Addition:</a>
+          Update the <a href="#el-address"><code>address</code></a> and <a href="#el-hgroup"><code>hgroup</code></a> element allowances per their updated mapping to the <code>group</code> role.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/455">9 July 2023 - Addition:</a>
+          Update the <a href="#el-aside"><code>aside</code></a> element to allow the dpub <code>doc-glossary</code> role.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/446">5 July 2023 - Addition:</a>
+          Update the <a href="#el-button"><code>button</code></a>, <a href="#el-input-button"><code>input type=button</code></a>, <a href="#el-input-image"><code>input type=image</code></a>
+          <a href="#el-input-reset"><code>input type=reset</code></a>, and <a href="#el-input-submit"><code>input type=submit</code></a> elements to align their allowed roles.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/469">29 June 2023 - Addition:</a>
+          Update the <a href="#el-s"><code>s</code></a> element allowed roles to indicate use of <code>role=deletion</code> on the element would be considered redundnat.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/435">31 May 2023 - Correction:</a>
+          Conditionally revise allowed <code>aria-*</code> attributes and roles on <a href="#el-summary"><code>summary</code></a> element.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/410">31 May 2023 - Correction:</a>
+          Update <a href="#el-li"><code>li</code></a> element role allowances in context to the element's ancestral relationship, or lack of, 
+          to a list element parent.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/401">24 March 2023 - Addition:</a>
+          The <a href="#el-search"><code>search</code></a> element has been added.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/447">6 March 2023 - Addition:</a>
+          Disallow <code>aria-hidden=true</code> on the <code>body</code> element.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/415">13 February 2023 - Addition:</a>
+          Update <code>figure</code> element role allowances to include <code>doc-example</code>.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/437">07 November 2022 - Correction:</a>
+          Revisions to 'any role' term description.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/383">14 July 2022 - Correction:</a>
+          Disallow roles and <code>aria-*</code> attributes on the <a href="#el-datalist"><code>datalist</code></a> element.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/372">16 April 2022 - Correction:</a>
+          <a href="#att-checked"><code>aria-checked</code></a> is not to be used on elements that support the <code>checked</code> attribute.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/402">03 April 2022 - Addition:</a>
+          Identify <a href="#dfn-naming-prohibited" id="ref-for-dfn-naming-prohibited-1">Naming Prohibited</a> elements.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/404">06 March 2022 - Addition:</a>
+          Allow <code>none</code> and <code>presentation</code> roles on <a href="#el-nav"><code>nav</code> element</a>.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/403">03 March 2022 - Addition:</a>
+          Restrict role allowances for <a href="#el-div"><code>div</code> element</a> when it is a child of a <code>dl</code> element.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/396">12 February 2022 - Addition &amp; Correction:</a>
+          Allow <code>combobox</code> role on <a href="#el-button"><code>button</code> element</a>. 
+          Allow <code>combobox</code> and <code>checkbox</code> roles on <a href="#el-input-button"><code>input type=button</code> element</a>. 
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/391">18 January 2022 - Addition:</a>
+          Added <a href="#docconformance-deprecated">Requirements for deprecated ARIA role, state and property attributes</a>.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/369">06 January 2022 - Addition:</a>
+          Change allowances for <code>doc-biblioentry</code> and <code>doc-endnote</code> roles on the <a href="#el-li"><code>li</code> element</a>. 
+          These roles are deprecated in <cite><a data-matched-text="[[[dpub-aria-1.1]]]" href="https://www.w3.org/TR/dpub-aria-1.1/">Digital Publishing WAI-ARIA Module 1.1</a></cite>.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/381">13 December 2021 - Correction:</a>
+          Allow <code>radio</code> role on <a href="#el-img"><code>img alt="some text"</code> element</a>.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/353">07 December 2021 - Correction:</a> 
+          Allow only <code>none</code> and <code>presentation</code> roles for <a href="#el-wbr"><code>wbr</code> element</a>. 
+          Allow only <code>aria-hidden</code> global attribute for <a href="#el-br"><code>br</code></a> and <a href="#el-wbr"><code>wbr</code></a> elements.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/367">02 December 2021 - Addition:</a> 
+          Allow <code>group</code> role on <a href="#el-section"><code>section</code> element</a>.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/360">16 November 2021 - Addition:</a>
+          Allow <code>link</code> and <code>button</code> roles on <a href="#el-area-no-href"><code>area</code> without <code>href</code> element</a>.
+        </li>
+        <li>
+          <a href="https://github.com/w3c/html-aria/pull/352">26 October 2021 - Addition:</a>
+          Allow <code>aria-hidden</code> attribute on the <a href="#el-picture"><code>picture</code> element</a>. 
+        </li>
+      </ul>
+      <p>
+        Reviewers of the document can identify candidate additions
+        and/or corrections by their distinctive styling in the document:
+      </p>
+      <p class="correction">Candidate corrections are marked in the document.</p>
+      <p class="addition">Candidate additions are marked in the document.</p>
+    <p>
+    This document was published by the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a> as
+    a Recommendation using the
+        <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation track</a>. It includes
+      <a href="https://www.w3.org/policies/process/20231103/#candidate-amendments">
+            candidate amendments</a>,
+      introducing substantive changes and new features since the previous
+      Recommendation.
+  </p><p>
+      <abbr title="World Wide Web Consortium">W3C</abbr> recommends the wide deployment of this specification as a standard for
+      the Web.
+    </p><p>
+      A <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation is a specification that, after extensive
+      consensus-building, is endorsed by
+      <abbr title="World Wide Web Consortium">W3C</abbr> and its Members, and
+      has commitments from Working Group members to
+      <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements">royalty-free licensing</a>
+      for implementations.
+      Future updates to this Recommendation may incorporate
+            <a href="https://www.w3.org/policies/process/20231103/#allow-new-features">new features</a>.
+    </p><p class="addition">
+          Candidate additions are marked in the document.
+        </p><p class="correction">
+          Candidate corrections are marked in the document.
+        </p><p>
+    
+        This document was produced by a group
+        operating under the
+        <a href="https://www.w3.org/policies/patent-policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
+          Policy</a>.
+      
+    
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+                <a rel="disclosure" href="https://www.w3.org/groups/wg/webapps/ipr">public list of any patent disclosures</a>
+          made in connection with the deliverables of
+          the group; that page also includes
+          instructions for disclosing a patent. An individual who has actual
+          knowledge of a patent that the individual believes contains
+          <a href="https://www.w3.org/policies/patent-policy/#def-essential">Essential Claim(s)</a>
+          must disclose the information in accordance with
+          <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+        
+  </p><p>
+                      This document is governed by the
+                      <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20231103/">03 November 2023 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+                    </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#rules-wd"><bdi class="secno">1. </bdi>
+        Author requirements for use of ARIA in HTML
+      </a></li><li class="tocline"><a class="tocxref" href="#aria-semantics-that-extend-and-diverge-from-html"><bdi class="secno">2. </bdi>ARIA semantics that extend and diverge from HTML</a></li><li class="tocline"><a class="tocxref" href="#author-guidance-to-avoid-incorrect-use-of-aria"><bdi class="secno">3. </bdi>
+        Author guidance to avoid incorrect use of ARIA
+      </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#avoid-overriding-interactive-elements-with-non-interactive-roles"><bdi class="secno">3.1 </bdi>
+          Avoid overriding interactive elements with non-interactive roles
+        </a></li><li class="tocline"><a class="tocxref" href="#avoid-specifying-redundant-roles"><bdi class="secno">3.2 </bdi>
+          Avoid specifying redundant roles
+        </a></li><li class="tocline"><a class="tocxref" href="#side-effects"><bdi class="secno">3.3 </bdi>
+          Be cautious of side effects
+        </a></li><li class="tocline"><a class="tocxref" href="#adhere-to-the-rules-of-aria"><bdi class="secno">3.4 </bdi>Adhere to the rules of ARIA</a></li><li class="tocline"><a class="tocxref" href="#adhere-to-the-rules-of-html"><bdi class="secno">3.5 </bdi>Adhere to the rules of HTML</a></li></ol></li><li class="tocline"><a class="tocxref" href="#docconformance"><bdi class="secno">4. </bdi>
+        Document conformance requirements for use of ARIA attributes in HTML
+      </a><ol class="toc"><li class="tocline"><a class="tocxref" href="#docconformance-naming"><bdi class="secno">4.1 </bdi>
+          Requirements for use of ARIA attributes to name  elements
+        </a></li><li class="tocline"><a class="tocxref" href="#docconformance-attr"><bdi class="secno">4.2 </bdi>
+          Requirements for use of ARIA attributes in place of equivalent HTML attributes
+        </a></li><li class="tocline"><a class="tocxref" href="#docconformance-deprecated"><bdi class="secno">4.3 </bdi>
+          Requirements for deprecated ARIA role, state and property and attributes
+        </a><ol class="toc"></ol></li><li class="tocline"><a class="tocxref" href="#case-sensitivity"><bdi class="secno">4.4 </bdi>
+        Case requirements for ARIA role, state and property attributes
+      </a></li></ol></li><li class="tocline"><a class="tocxref" href="#allowed-descendants-of-aria-roles"><bdi class="secno">5. </bdi>
+        Allowed descendants of ARIA roles
+      </a></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">6. </bdi>Conformance</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance-checking-requirements"><bdi class="secno">6.1 </bdi>Conformance checking requirements</a></li></ol></li><li class="tocline"><a class="tocxref" href="#priv-sec"><bdi class="secno">7. </bdi>
+        Privacy and security considerations
+      </a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">A. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">A.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">A.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+    <section id="author-requirements-for-use-of-aria-in-html"><div class="header-wrapper"><h2 id="rules-wd"><bdi class="secno">1. </bdi>
+        Author requirements for use of ARIA in HTML
+      </h2><a class="self-link" href="#rules-wd" aria-label="Permalink for Section 1."></a></div>
+      
+      <p>
+        Authors <em class="rfc2119">MAY</em> use the ARIA <code>role</code> and <code>aria-*</code> attributes to change
+        the exposed meaning (<a href="https://html.spec.whatwg.org/multipage/dom.html#semantics-2">semantics</a>) of
+        <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">HTML elements</a>, in accordance with the requirements defined by
+        <cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">WAI-ARIA</a></cite>, except where ARIA features conflict with the
+        <dfn id="dfn-strong-native-semantics" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict">strong native semantics</a></dfn>
+        or are equal to the
+        <dfn id="dfn-implicit-aria-semantics" class="externalDFN" data-no-export="" data-dfn-type="dfn"><a href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a></dfn>
+        of a given HTML element. The <a data-link-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a> for the features
+        of HTML are defined by the <cite><a class="bibref" data-link-type="biblio" href="#bib-html-aam-1.0" title="HTML Accessibility API Mappings 1.0">HTML Accessibility API Mappings</a></cite> specification.
+      </p>
+      <p>
+        Any constraints for the use of ARIA features in HTML defined by this specification 
+        are intended to prevent authors from making assistive technology products report 
+        nonsensical user interface (UI) information that does not represent the actual UI
+        of the document.
+      </p>
+      <p>
+        Authors <em class="rfc2119">MUST NOT</em> use the ARIA <code>role</code> and <code>aria-*</code> attributes in a manner that conflicts 
+        with the semantics described in the <a href="#docconformance" data-matched-text="[[[#docconformance]]]" class="sec-ref"><bdi class="secno">4. </bdi>
+        Document conformance requirements for use of ARIA attributes in HTML</a> and <a href="#docconformance-attr" data-matched-text="[[[#docconformance-attr]]]" class="sec-ref"><bdi class="secno">4.2 </bdi>
+          Requirements for use of ARIA attributes in place of equivalent HTML attributes</a> 
+        tables. It is <em class="rfc2119">NOT RECOMMENDED</em> for authors to set the ARIA <code>role</code> and <code>aria-*</code> attributes 
+        to values that match the <a data-link-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a> defined in either table. 
+        Doing so is unnecessary and can potentially lead to unintended consequences.
+      </p>
+    </section>
+    <section class="informative" id="aria-semantics-that-extend-and-diverge-from-html"><div class="header-wrapper"><h2 id="x2-aria-semantics-that-extend-and-diverge-from-html"><bdi class="secno">2. </bdi>ARIA semantics that extend and diverge from HTML</h2><a class="self-link" href="#aria-semantics-that-extend-and-diverge-from-html" aria-label="Permalink for Section 2."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <p>
+        Through the use of ARIA, authors can specify semantics that go beyond the current 
+        capabilities of native HTML. This can be very useful, as it provides authors the opportunity 
+        to create widgets, or expose specific accessible states and properties to native HTML features 
+        which would not be possible by the use of HTML alone.
+      </p>
+      <p>
+        For instance, a <code>button</code> element has no native HTML feature to expose a "pressed" state.
+        ARIA allows authors to extend the semantics of the element by specifying the <code>aria-pressed</code>
+        attribute, allowing for an aural UI that will match the visual presentation of the control.
+      </p>
+      <p>
+        In the following example, a <code>button</code> element allows for a user to toggle the state of a 
+        setting within a web application. The <code>aria-pressed</code> attribute is used to 
+        augment the <code>button</code> element. When in the "pressed" state that information can be
+        exposed to users of assistive technologies.
+      </p>
+      <div class="example" id="example-communicate-a-button-s-pressed-state-with-aria">
+        <div class="marker">
+    <a class="self-link" href="#example-communicate-a-button-s-pressed-state-with-aria">Example<bdi> 1</bdi></a><span class="example-title">: Communicate a button's pressed state with ARIA</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">aria-pressed</span>=<span class="hljs-string">true</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span></code></pre>
+      </div>
+      <p>
+        There are also situations where certain <code>aria-*</code> attributes are allowed for use on elements 
+        with specific <code>role</code>s, while the equivalent native attribute is currently not valid in HTML itself.
+      </p>
+      <p>
+        For instance, HTML has no direct concept of a disabled hyperlink (<code>a href</code> element). 
+        Constructs such as <code>&lt;a href="..." disabled&gt; ... &lt;/a&gt;</code> are not valid, 
+        and will not be conveyed to assistive technologies. 
+      </p>
+      <p>
+        ARIA diverges from HTML in this regard and does allow for an <code>aria-disabled</code>
+        attribute to be specified on an element with an explicit <code>role=link</code>. If an author were
+        to specify an <code>aria-disabled=true</code> on an HTML hyperlink, user agents would not functionally
+        treat the hyperlink any differently (it would still be clickable/operable), however it 
+        would be exposed to assistive technologies as being in the disabled state.
+      </p>
+      <p>
+        Similarly, while native HTML <code>option</code> elements that are descendants of a <code>select</code> can 
+        only be set as being <code>selected</code>, elements with an explicit <code>option</code> role can not only 
+        allow the equivalent <code>aria-selected</code>, but also the <code>aria-checked</code> attribute, supporting
+        widgets/constructs that go beyond the capabilities of a native <code>select</code> element.
+      </p>
+      <p>
+        Unfortunately, in these situations where ARIA and HTML have feature parity, but diverge 
+        in allowances, it can create for a misalignment in support, if not also user experiences. 
+        In situations where ARIA allows a feature not supported by HTML, it will often
+        be in the author's and ultimately the user's best interest to instead implement as a 
+        fully custom ARIA widget.
+      </p>
+      <p>
+        In the following example, a hyperlink needs to be communicated as being in the disabled
+        state. HTML does not allow for the use of the <code>disabled</code> attribute on a hyperlink,
+        and using <code>aria-disabled=true</code> would communicate the hyperlink as being disabled to 
+        assistive technologies, but would not actually disable the element. The most effective way 
+        to both communicate and actually disable a hyperlink would be to remove the <code>href</code> from 
+        the <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">a</a></code> element, creating a placeholder. Then, ARIA can be applied to this
+        placeholder link to communicate the element's intended role and state.
+      </p>
+      <div class="example" id="example-communicate-a-disabled-link-with-aria">
+        <div class="marker">
+    <a class="self-link" href="#example-communicate-a-disabled-link-with-aria">Example<bdi> 2</bdi></a><span class="example-title">: Communicate a disabled link with ARIA</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">a</span> <span class="hljs-attr">role</span>=<span class="hljs-string">link</span> <span class="hljs-attr">aria-disabled</span>=<span class="hljs-string">true</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">a</span>&gt;</span></code></pre>
+      </div>
+    </section>
+    <section class="informative" id="author-guidance-to-avoid-incorrect-use-of-aria"><div class="header-wrapper"><h2 id="x3-author-guidance-to-avoid-incorrect-use-of-aria"><bdi class="secno">3. </bdi>
+        Author guidance to avoid incorrect use of ARIA
+      </h2><a class="self-link" href="#author-guidance-to-avoid-incorrect-use-of-aria" aria-label="Permalink for Section 3."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <section id="avoid-overriding-interactive-elements-with-non-interactive-roles"><div class="header-wrapper"><h3 id="x3-1-avoid-overriding-interactive-elements-with-non-interactive-roles"><bdi class="secno">3.1 </bdi>
+          Avoid overriding interactive elements with non-interactive roles
+        </h3><a class="self-link" href="#avoid-overriding-interactive-elements-with-non-interactive-roles" aria-label="Permalink for Section 3.1"></a></div>
+        
+        <p>
+          ARIA is useful for revising or correcting the role of an element when a different role
+          is necessary to expose to users. However, it is rarely in the user or author's best interest
+          to try and use ARIA to override an interactive element, for instance a <code>button</code>, with a role
+          generally exposed by a non-interactive element. For instance, a heading.
+        </p>
+        <p>
+          As an example, the following uses a <code>role=heading</code> on a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">button</a></code> element. This is
+          not allowed, because the <code>button</code> element has default functionality that conflicts with user 
+          expectations for the heading role.
+        </p>
+        <div class="example" id="example-wrong-role">
+        <div class="marker">
+    <a class="self-link" href="#example-wrong-role">Example<bdi> 3</bdi></a><span class="example-title">: Wrong role</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"heading"</span>&gt;</span>search<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span></code></pre>
+      </div>
+        <p>
+          An author would need to take additional steps to ensure the default functionality and presentation of 
+          the <code>button</code> was removed, and even doing so may still not be enough to fully supress the element's 
+          implicit features depending on how the user chooses to engage with the web page. E.g., by turning on 
+          Windows high contrast themes, or viewing the web page in a browser's reader mode.
+        </p>
+      </section>
+      <section id="avoid-specifying-redundant-roles"><div class="header-wrapper"><h3 id="x3-2-avoid-specifying-redundant-roles"><bdi class="secno">3.2 </bdi>
+          Avoid specifying redundant roles
+        </h3><a class="self-link" href="#avoid-specifying-redundant-roles" aria-label="Permalink for Section 3.2"></a></div>
+        
+        <p>
+          The following example illustrates a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">button</a></code> element which has also been
+          provided an explicit <code>role=button</code>. Specifying this role is unnecessary, as a "button" 
+          element is already exposed with an implicit <code>button</code> role. In practice this particular
+          instance of redundancy will likely not have unforeseen side effects, other than 
+          unnecessarily making the markup more verbose, and incorrectly signaling to other authors 
+          that this practice is useful. Please review the section <a href="#side-effects" data-matched-text="[[[#side-effects]]]" class="sec-ref"><bdi class="secno">3.3 </bdi>
+          Be cautious of side effects</a>
+          for an example of where specifying unnecessary roles can be problematic.
+        </p>
+        <div class="example" id="example-redundant-role-on-button">
+        <div class="marker">
+    <a class="self-link" href="#example-redundant-role-on-button">Example<bdi> 4</bdi></a><span class="example-title">: Redundant role on button</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- Avoid doing this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">button</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"button"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span></code></pre>
+      </div>
+        <p>
+          Similarly, the following uses a <code>role=group</code> on a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element">fieldset</a></code> element, and a <code>role=Main</code> on a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a></code> element.
+          This is unnecessary, because the <code>fieldset</code> element is implicitly exposed as a <code>role=group</code>, as is the <code>main</code> element 
+          implicitly exposed as a <code>role=main</code>. Again, in practice this will likely not have any unforeseen side effects to users 
+          of assistive technology, as long as the declaration of the <code>role</code> value uses <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-lowercase">ASCII lowercase</a>. 
+          Please see <a href="#case-sensitivity" data-matched-text="[[[#case-sensitivity]]]" class="sec-ref"><bdi class="secno">4.4 </bdi>
+        Case requirements for ARIA role, state and property attributes</a> for more information.
+        </p>
+        <div class="example" id="example-redundant-role-on-fieldset-and-main">
+        <div class="marker">
+    <a class="self-link" href="#example-redundant-role-on-fieldset-and-main">Example<bdi> 5</bdi></a><span class="example-title">: Redundant role on fieldset and main</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- Avoid doing this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">fieldset</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"group"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">fieldset</span>&gt;</span>
+<span class="hljs-comment">&lt;!-- or this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">main</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"Main"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">main</span>&gt;</span></code></pre>
+      </div>
+        <p>
+          The following uses a <code>role=list</code> on an <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element">ul</a></code> element. As the <code>ul</code> element has an implicit role of <code>list</code>, 
+          explicitly adding the role would generally be considered redundant. However, some user agents suppress a list's
+          implicit ARIA semantics if the list markers are removed from the visual presentation of the list items. 
+          Generally the redundant declaration of an element's implicit role would not be recommended, but in specific situations
+          such as this, and where the role is necessary to expose, authors can explicitly add the role.
+        </p>
+        <div class="example" id="example-redundant-role-on-list">
+        <div class="marker">
+    <a class="self-link" href="#example-redundant-role-on-list">Example<bdi> 6</bdi></a><span class="example-title">: Redundant role on list</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- Generally avoid doing this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">ul</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"list"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">ul</span>&gt;</span></code></pre>
+      </div>
+      </section>
+      <section id="be-cautious-of-side-effects"><div class="header-wrapper"><h3 id="side-effects"><bdi class="secno">3.3 </bdi>
+          Be cautious of side effects
+        </h3><a class="self-link" href="#side-effects" aria-label="Permalink for Section 3.3"></a></div>
+        
+        <p>
+          The following uses a <code>role=button</code> on a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element">summary</a></code> element. This is
+          unnecessary and can result in cross-platform issues. For instance,
+          preventing the element from correctly exposing its state, and forcing
+          the role of <code>button</code>, when it might otherwise be exposed with a
+          platform or browser specific role.
+        </p>
+        <div class="example" id="example-unintended-consequences">
+        <div class="marker">
+    <a class="self-link" href="#example-unintended-consequences">Example<bdi> 7</bdi></a><span class="example-title">: Unintended consequences</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">details</span>&gt;</span>
+  <span class="hljs-comment">&lt;!-- Avoid doing this! --&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">summary</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"button"</span>&gt;</span>more information<span class="hljs-tag">&lt;/<span class="hljs-name">summary</span>&gt;</span>
+  ...
+<span class="hljs-tag">&lt;/<span class="hljs-name">details</span>&gt;</span></code></pre>
+      </div>
+      </section>
+      <section id="adhere-to-the-rules-of-aria"><div class="header-wrapper"><h3 id="x3-4-adhere-to-the-rules-of-aria"><bdi class="secno">3.4 </bdi>Adhere to the rules of ARIA</h3><a class="self-link" href="#adhere-to-the-rules-of-aria" aria-label="Permalink for Section 3.4"></a></div>
+        
+        <p>
+          <cite><a data-matched-text="[[[wai-aria-1.2]]]" href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> defines a number of roles which are not meant to be used
+          by authors. Many of these roles are categorized as <a href="https://www.w3.org/TR/wai-aria-1.2/#isAbstract">Abstract Roles</a>
+          which are explicitly stated as not to be used by authors. The following example illustrates the invalid use of an
+          abstract <code>select</code> role, where an author likely meant to use the <code>combobox</code> role instead.
+        </p>
+        <div class="example" id="example-abstract-roles-are-not-for-authors">
+        <div class="marker">
+    <a class="self-link" href="#example-abstract-roles-are-not-for-authors">Example<bdi> 8</bdi></a><span class="example-title">: Abstract roles are not for authors</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- Do not do this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"select"</span> <span class="hljs-attr">...</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></code></pre>
+      </div>
+        <p>
+          ARIA also defines a <a href="https://www.w3.org/TR/wai-aria-1.2/#generic"><code>generic</code> role</a> which is meant to provide
+          feature parity with a number of HTML elements that do not have more specific ARIA semantics of their
+          own. For instance, HTML's <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">div</a></code> and <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">span</a></code> elements, among others. ARIA discourages authors from
+          using the <code>generic</code> role as its intended purpose is for use by implementors of user agents.
+        </p>
+        <p>
+          In the following example, rather than using a <code>generic</code> role, authors are advised to use a <code>div</code> in 
+          place of the <code>article</code> element. If changing the HTML element is not possible, specifying a role of 
+          <code>presentation</code> or <code>none</code> would be acceptable alternaties to remove the implicit role of the <code>article</code>.
+        </p>
+        <div class="example" id="example-do-not-specify-elements-as-generic">
+        <div class="marker">
+    <a class="self-link" href="#example-do-not-specify-elements-as-generic">Example<bdi> 9</bdi></a><span class="example-title">: Do not specify elements as generic</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- Avoid doing this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">article</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"generic"</span> <span class="hljs-attr">...</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">article</span>&gt;</span></code></pre>
+      </div>
+        <p>
+          Additionally, ARIA specifically mentions in <a href="https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict">Conflicts with Host Language Semantics</a> 
+          that if authors use both native HTML features for exposing states and properties as well as their ARIA counterparts, then
+          the host language features take priority over the explicit ARIA attributes that are also used.
+        </p>
+        <p>
+          For instance, in the following example an author is using HTML's <code>input type=checkbox</code> and has specified an <code>aria-checked=true</code>. However,
+          user agents are meant to ignore the <code>aria-checked</code> attribute. Instead user agents would expose the state based on the native features
+          of the form control.
+        </p>
+        <div class="example" id="example-the-implicit-checked-state-takes-precedent-over-the-explicit-aria-attribute">
+        <div class="marker">
+    <a class="self-link" href="#example-the-implicit-checked-state-takes-precedent-over-the-explicit-aria-attribute">Example<bdi> 10</bdi></a><span class="example-title">: The implicit checked state takes precedent over the explicit ARIA attribute</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- Do not do this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">input</span> <span class="hljs-attr">type</span>=<span class="hljs-string">"checkbox"</span> <span class="hljs-attr">checked</span> <span class="hljs-attr">aria-checked</span>=<span class="hljs-string">"false"</span>&gt;</span></code></pre>
+      </div>
+      </section>
+      <section id="adhere-to-the-rules-of-html"><div class="header-wrapper"><h3 id="x3-5-adhere-to-the-rules-of-html"><bdi class="secno">3.5 </bdi>Adhere to the rules of HTML</h3><a class="self-link" href="#adhere-to-the-rules-of-html" aria-label="Permalink for Section 3.5"></a></div>
+        
+        <p>
+          While ARIA can be used to alter the way HTML features are exposed to users of assistive technologies,
+          these modifications do not change the underlying parsing and allowed content models of HTML. For instance,
+          a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">div</a></code> allows an author to specify any role on it. However, this does not mean that the element can then be
+          used in a way that deviates from the rules HTML has defined for the element.
+        </p>
+        <p>
+          For instance, in the following example an author has specified a role of <code>link</code> on a <code>div</code> element. While
+          HTML allows for a hyperlink (exposed as a <code>role=link</code>) to be a descendant of a <code>p</code> element, the HTML parser does not
+          allow a <code>div</code> to be a descendant of a <code>p</code> element. 
+        </p>
+        <div class="example" id="example-revised-aria-semantics-with-invalid-html-nesting">
+        <div class="marker">
+    <a class="self-link" href="#example-revised-aria-semantics-with-invalid-html-nesting">Example<bdi> 11</bdi></a><span class="example-title">: Revised ARIA semantics with invalid HTML nesting</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- Do not do this! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>
+  ... <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">link</span> <span class="hljs-attr">tabindex</span>=<span class="hljs-string">0</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span> ... 
+<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span></code></pre>
+      </div>
+        <p>
+          The HTML parser will modify the above markup to be output as the following:
+        </p>
+        <div class="example" id="example-unwanted-rendered-markup-with-valid-alternative-solution">
+        <div class="marker">
+    <a class="self-link" href="#example-unwanted-rendered-markup-with-valid-alternative-solution">Example<bdi> 12</bdi></a><span class="example-title">: Unwanted rendered markup with valid alternative solution</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- The previous example's markup will render as follows --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">link</span> <span class="hljs-attr">tabindex</span>=<span class="hljs-string">0</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span> 
+... 
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+
+<span class="hljs-comment">&lt;!-- Instead of a div, use a span. Spans are allowed descendants of p elements! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span>&gt;</span>
+  ... <span class="hljs-tag">&lt;<span class="hljs-name">span</span> <span class="hljs-attr">role</span>=<span class="hljs-string">link</span> <span class="hljs-attr">tabindex</span>=<span class="hljs-string">0</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">span</span>&gt;</span> ...
+<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span></code></pre>
+      </div>
+        <p>
+          While this specification indicates the allowed ARIA attributes that can be specified on each HTML element,
+          this example illustrates that even if a role is allowed, the context in which it is used can still result
+          in potential rendering and accessibility issues.
+        </p>
+      </section>
+    </section>
+    <section id="document-conformance-requirements-for-use-of-aria-attributes-in-html"><div class="header-wrapper"><h2 id="docconformance"><bdi class="secno">4. </bdi>
+        Document conformance requirements for use of ARIA attributes in HTML
+      </h2><a class="self-link" href="#docconformance" aria-label="Permalink for Section 4."></a></div>
+      
+      <p>
+        The following table provides normative per-element document conformance requirements for the 
+        use of ARIA markup in HTML documents. Additionally, it identifies the <a data-link-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a> 
+        that apply to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">HTML elements</a>. The <a data-link-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a> of these elements are defined 
+        in <cite><a class="bibref" data-link-type="biblio" href="#bib-html-aam-1.0" title="HTML Accessibility API Mappings 1.0">HTML AAM</a></cite>.
+      </p>
+      <p>
+        Each language feature (element) in a cell in the first column implies the ARIA semantics 
+        (role, states, and properties) given in the cell in  the second column of the same row. 
+        The third cell in each row defines the ARIA <code>role</code> values and <code>aria-*</code> attributes which authors <em class="rfc2119">MAY</em> specify
+        on the element. Where a cell in the third column includes the term <dfn id="dfn-any-role" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn"><strong>Any</strong> <code>role</code></dfn>
+        it indicates that any <code>role</code> value <span class="addition correction"><em class="rfc2119">MAY</em> be used on the element. However, 
+        it is <em class="rfc2119">NOT RECOMMENDED</em> for authors to specify the implicit role of the element, the <code>generic</code> role, or a role 
+        <a href="#docconformance-deprecated">deprecated by ARIA</a> on these elements.</span> 
+        If a cell in the third column includes the term <dfn id="dfn-no-role" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn"><strong>No <code>role</code></strong></dfn> it indicates 
+        that authors <em class="rfc2119">MUST NOT</em> overwrite the implicit ARIA semantics, or native semantics of the HTML element. 
+      </p>
+      <div class="addition">
+        <p>
+          <cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">WAI-ARIA</a></cite> identifies roles which have 
+          <a href="https://www.w3.org/TR/wai-aria-1.2/#prohibitedattributes">prohibited states and properties</a>.
+          These roles do not allow certain WAI-ARIA attributes to be specified by authors.
+          HTML elements which expose these implicit WAI-ARIA roles also prohibit authors from
+          specifying these WAI-ARIA attributes.
+        </p>
+        <p>
+          Elements which are identified as <dfn id="dfn-naming-prohibited" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">Naming prohibited</dfn> are those which authors <em class="rfc2119">MUST NOT</em> specify an 
+          <code>aria-label</code> or <code>aria-labelledby</code> attribute, unless the element allows for its implicit role to be overwritten 
+          by an explicit WAI-ARIA role which allows naming from authors. For more information see <a href="#docconformance-naming" data-matched-text="[[[#docconformance-naming]]]" class="sec-ref"><bdi class="secno">4.1 </bdi>
+          Requirements for use of ARIA attributes to name  elements</a>.
+        </p>
+      </div>
+      <div class="note" role="note" id="aria-usage-note"><div role="heading" class="note-title marker" id="h-note" aria-level="3"><span>Note</span></div><p class="">
+        While setting an ARIA <code>role</code> and/or <code>aria-*</code> attribute that matches the <span>implicit ARIA semantics</span>
+        is <em class="rfc2119">NOT RECOMMENDED</em>, in some  situations explicitly setting these attributes can be helpful – for instance, 
+        for user agents that do not expose implicit ARIA semantics for certain elements.
+      </p></div>
+      <div class="note" role="note" id="dpub-usage-note"><div role="heading" class="note-title marker" id="h-note-0" aria-level="3"><span>Note</span></div><p class="">
+        While it is conforming to use <cite><a data-matched-text="[[[dpub-aria-1.0]]]" href="https://www.w3.org/TR/dpub-aria-1.0/">Digital Publishing WAI-ARIA Module 1.0</a></cite> <code>role</code> values as outlined in the following table, the use of these roles
+        is not intended for implementation of websites. If using these role for purposes beyond the scope of the digital publishing 
+        industry, further manual testing will be necessary to ensure the intended experience is provided to users.
+      </p></div>
+      <table class="data">
+        <caption>
+          Rules of ARIA attribute usage by HTML element
+        </caption>
+        <thead>
+          <tr>
+            <th>
+              HTML element
+            </th>
+            <th>
+              <p id="implicit">
+                Implicit ARIA semantics
+                <small>(explicitly assigning these in markup is <em class="rfc2119">NOT RECOMMENDED</em>)</small>
+              </p>
+            </th>
+            <th>
+              ARIA role, state and property allowances
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th id="el-a" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">a</a></code> with <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href">href</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-link">link</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-button"><code>button</code></a>,
+                <a href="#index-aria-checkbox"><code>checkbox</code></a>,
+                <a href="#index-aria-menuitem"><code>menuitem</code></a>,
+                <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>,
+                <a href="#index-aria-option"><code>option</code></a>,
+                <a href="#index-aria-radio"><code>radio</code></a>,
+                <a href="#index-aria-switch"><code>switch</code></a>,
+                <a href="#index-aria-tab"><code>tab</code></a>
+                or <a href="#index-aria-treeitem"><code>treeitem</code></a>. (<code><a href="#index-aria-link">link</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                DPub Roles:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-backlink"><code>doc-backlink</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-biblioref"><code>doc-biblioref</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossref"><code>doc-glossref</code></a>
+                or <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-noteref"><code>doc-noteref</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> and
+                any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <p>
+                It is <em class="rfc2119">NOT RECOMMENDED</em> to use <code>aria-disabled="true"</code> on an
+                <code>a</code> element with an <code>href</code> attribute.
+              </p>
+              <div class="note" role="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note-1" aria-level="3"><span>Note</span></div><div class="">
+                If a link needs to be programmatically communicated as "disabled", 
+                <a href="#example-communicate-a-disabled-link-with-aria">remove the <code>href</code> attribute</a>.
+              </div></div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-a-no-href" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">a</a></code> without <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href">href</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-1"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-2">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a>
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-abbr" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-abbr-element">abbr</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-1">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-2"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-3">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-address" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-address-element">address</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-group">group</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-3"><strong>Any <code>role</code></strong></a>, though <a href="#index-aria-group"><code>group</code></a> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-area" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">area</a></code> with <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href">href</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-link">link</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-1"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-link">link</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the 
+                <a href="#index-aria-link"><code>link</code></a> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-area-no-href" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element">area</a></code> without <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href">href</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <div class="addition">
+                <p>
+                  Roles:
+                  <a href="#index-aria-button"><code>button</code></a>
+                  or <a href="#index-aria-link"><code>link</code></a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but <em class="rfc2119">SHOULD NOT</em> be used.)
+                </p>
+                <p><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-4">Naming Prohibited</a></p>
+                <p>
+                  Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                  and any <code>aria-*</code> attributes applicable to the allowed roles.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-article" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-article-element">article</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-article">article</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-application"><code>application</code></a>,
+                <a href="#index-aria-document"><code>document</code></a>,
+                <a href="#index-aria-feed"><code>feed</code></a>,
+                <a href="#index-aria-main"><code>main</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>
+                or <a href="#index-aria-region"><code>region</code></a>. (<code><a href="#index-aria-article">article</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-aside" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-aside-element">aside</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-complementary">complementary</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-feed"><code>feed</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-note"><code>note</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>,
+                <a href="#index-aria-region"><code>region</code></a>
+                or <a href="#index-aria-search"><code>search</code></a>. (<code><a href="#index-aria-complementary">complementary</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                DPub Roles:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-dedication"><code>doc-dedication</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-example"><code>doc-example</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-footnote"><code>doc-footnote</code></a>,
+                <span class="proposed addition"><a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossary"><code>doc-glossary</code></a>,</span>
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pullquote"><code>doc-pullquote</code></a>
+                or <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-tip"><code>doc-tip</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-audio" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#audio">audio</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-2">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Role:
+                <a href="#index-aria-application"><code>application</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the 
+                <a href="#index-aria-application"><code>application</code></a> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-autonomous-custom-element" tabindex="-1">
+              <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/custom-elements.html#autonomous-custom-element">autonomous custom element</a>
+            </th>
+            <td>
+              <p>
+                Role exposed from author defined <a data-link-type="interface" data-lt="ElementInternals" href="https://html.spec.whatwg.org/multipage/custom-elements.html#elementinternals"><code>ElementInternals</code></a>
+              </p>
+              <p>
+                Otherwise <code>role=<a href="#index-aria-generic">generic</a></code>
+              </p>
+            </td>
+            <td>
+              <p>
+                If role defined by <code>ElementInternals</code>, 
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-2"><strong class="nosupport">no <code>role</code></strong></a>
+              </p>
+              <p>
+                Otherwise, <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-4"><strong>any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition">
+                <a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-5">Naming Prohibited</a> if exposed as the <code>generic</code> role, or if exposed
+                as another role which prohibits naming.
+              </p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-b" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element">b</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-5"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-6">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-base" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element">base</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-3">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-3">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-bdi" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdi-element">bdi</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-6"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-7">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-bdo" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element">bdo</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-7"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-8">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-blockquote" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element">blockquote</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-blockquote"><code>blockquote</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-8"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-blockquote"><code>blockquote</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-body" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-body-element">body</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-4"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-generic">generic</a></code>, which <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-9">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                <span class="addition proposal">
+                  allowed for the <code>generic</code> role, with the exception that authors <em class="rfc2119">MUST NOT</em> specify <code>aria-hidden=true</code> on the <code>body</code> element.
+                </span>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-br" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element">br</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-4">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-none"><code>none</code></a>
+                or <a href="#index-aria-presentation"><code>presentation</code></a>
+              </p>
+              <p class="addition">
+                Authors <em class="rfc2119">MAY</em> specify the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden"><code>aria-hidden</code></a> attribute on the <code>br</code> element.
+                Otherwise, no other allowed <code>aria-*</code> attributes.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-button" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">button</a></code>
+            </th>
+            <td>
+              <p><code>role=<a href="#index-aria-button">button</a></code></p>
+              <p>If the <code>button</code> is the first child of a <code>select</code> element, the element is <code>inert</code>.</p>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-checkbox"><code>checkbox</code></a>,
+                <span class="addition"><a href="#index-aria-combobox"><code>combobox</code></a></span>,
+                <span class="proposed addition"><a href="#index-aria-gridcell"><code>gridcell</code></a></span>,
+                <a href="#index-aria-link"><code>link</code></a>,
+                <a href="#index-aria-menuitem"><code>menuitem</code></a>,
+                <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>,
+                <a href="#index-aria-option"><code>option</code></a>,
+                <a href="#index-aria-radio"><code>radio</code></a>,
+                <span class="proposed addition">
+                  <a href="#index-aria-separator"><code>separator</code></a>,
+                  <a href="#index-aria-slider"><code>slider</code></a></span>,
+                <a href="#index-aria-switch"><code>switch</code></a>,
+                <a href="#index-aria-tab"><code>tab</code></a>,
+                or <span class="proposed addition"><a href="#index-aria-treeitem"><code>treeitem</code></a></span>.
+                (<code><a href="#index-aria-button">button</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <hr>
+              <p>If the <code>button</code> is the first child of a <code>select</code> element:
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-5">No <code>role</code></a> or <code>aria-*</code> attributes</strong></p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-canvas" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/canvas.html#canvas">canvas</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-5">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-9"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-caption" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-caption-element">caption</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-caption"><code>caption</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-6"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-caption"><code>caption</code></a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-10">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a>.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-cite" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-cite-element">cite</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-6">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-10"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-11">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-code" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-code-element">code</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-code"><code>code</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-11"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-code"><code>code</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-12">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-col" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-col-element">col</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-7">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-7">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-colgroup" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-colgroup-element">colgroup</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-8">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-8">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-data" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-data-element">data</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-12"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-13">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-datalist" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element">datalist</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-listbox">listbox</a></code>
+            </td>
+            <td>
+              <div class="correction">
+                <p>
+                  <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-9"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-listbox">listbox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+                </p>
+                <p>
+                  <strong>No <code>aria-*</code> attributes</strong>.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-dd" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dd-element">dd</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-9">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-10"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>definition</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-del" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/edits.html#the-del-element">del</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-deletion"><code>deletion</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-13"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-deletion"><code>deletion</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-14">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-details" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">details</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-group">group</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-11"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-group">group</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>group</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-dfn" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-dfn-element">dfn</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-term">term</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-14"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-term">term</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-dialog" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element">dialog</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-dialog">dialog</a></code>
+            </td>
+            <td>
+              <p>
+                Role:
+                <a href="#index-aria-alertdialog"><code>alertdialog</code></a>. (<code><a href="#index-aria-dialog">dialog</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>dialog</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-div" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">div</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p class="addition">
+                If a direct child of a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element">dl</a></code> element,
+                only <a href="#index-aria-presentation"><code>presentation</code></a>
+                or <a href="#index-aria-none"><code>none</code></a>. Otherwise,
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-15"><strong>any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-15">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-dl" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dl-element">dl</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-10">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-list"><code>list</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>
+                or <a href="#index-aria-presentation"><code>presentation</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-dt" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element">dt</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-11">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Role:
+                <a href="#index-aria-listitem"><code>listitem</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-em" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-em-element">em</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-emphasis"><code>emphasis</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-16"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-emphasis"><code>emphasis</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-16">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-embed" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element">embed</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-12">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-application"><code>application</code></a>,
+                <a href="#index-aria-document"><code>document</code></a>,
+                <a href="#index-aria-img"><code>img</code></a>,
+                <a href="#index-aria-img"><code>image</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>
+                or <a href="#index-aria-presentation"><code>presentation</code></a>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> and
+                any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-fieldset" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element">fieldset</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-group">group</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>
+                or <a href="#index-aria-radiogroup"><code>radiogroup</code></a>. (<code><a href="#index-aria-group">group</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-figcaption" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figcaption-element">figcaption</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-13">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>
+                or <a href="#index-aria-presentation"><code>presentation</code></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-17">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-figure" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element">figure</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-figure">figure</a></code>
+            </td>
+            <td>
+              <p>
+                If the <code>figure</code> has a valid <code>figcaption</code> descendant:
+                <br>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-12"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-figure">figure</a></code>, 
+                which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                DPub Role:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-example"><code>doc-example</code></a>.
+              </p>
+              <p>
+                Otherwise, if the <code>figure</code> has no <code>figcaption</code> descendant:
+                <br>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-17"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-figure">figure</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-footer" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-footer-element">footer</a></code>
+            </th>
+            <td>
+              <p>
+                If not a descendant of an <code>article</code>, <code>aside</code>, <code>main</code>, <code>nav</code>
+                or <code>section</code> element, or an element with <code>role=article</code>, <code>complementary</code>,
+                <code>main</code>, <code>navigation</code> or <code>region</code>
+                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
+              </p>
+              <p>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+              </p>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>
+                or <a href="#index-aria-none"><code>none</code></a>.
+                (If not a descendant of an <code>article</code>, <code>aside</code>, <code>main</code>, <code>nav</code>
+                or <code>section</code> element, or an element with <code>role=article</code>, <code>complementary</code>,
+                <code>main</code>, <code>navigation</code> or <code>region</code>,
+                then <code>role=<a href="#index-aria-contentinfo">contentinfo</a></code>
+                is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+                is also allowed, but <em class="rfc2119">SHOULD NOT</em> be used.)
+              </p>
+              <p>
+                DPub Role:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-footnote"><code>doc-footnote</code></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-18">Naming Prohibited</a> if exposed as <code>generic</code>.</p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-form" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">form</a></code>
+            </th>
+            <td>
+              <p>
+                <code>role=<a href="#index-aria-form">form</a></code>
+              </p>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>
+                or <a href="#index-aria-search"><code>search</code></a>. (<code><a href="#index-aria-form">form</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <div class="note" role="note" id="issue-container-generatedID-0"><div role="heading" class="note-title marker" id="h-note-2" aria-level="3"><span>Note</span></div><p class="">
+                A <code>form</code> is not exposed as a landmark region unless it has been provided an <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a>.
+              </p></div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-form-associated-custom-element" tabindex="-1">
+              <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/custom-elements.html#form-associated-custom-element">form-associated custom element</a>
+            </th>
+            <td>
+              <p>
+                Role exposed from author defined <a data-link-type="interface" data-lt="ElementInternals" href="https://html.spec.whatwg.org/multipage/custom-elements.html#elementinternals"><code>ElementInternals</code></a>
+              </p>
+              <p>
+                Otherwise <code>role=<a href="#index-aria-generic">generic</a></code>
+              </p>
+            </td>
+            <td>
+              <p>
+                If role defined by <code>ElementInternals</code>, 
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-13"><strong class="nosupport">no <code>role</code></strong></a>
+              </p>
+              <p>
+                Otherwise, form-related roles:
+                <a href="#index-aria-button"><code>button</code></a>,
+                <a href="#index-aria-checkbox"><code>checkbox</code></a>,
+                <a href="#index-aria-combobox"><code>combobox</code></a>,
+                <a href="#index-aria-listbox"><code>listbox</code></a>,
+                <a href="#index-aria-progressbar"><code>progressbar</code></a>,
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-radio"><code>radio</code></a>,
+                <a href="#index-aria-radiogroup"><code>radiogroup</code></a>,
+                <a href="#index-aria-searchbox"><code>searchbox</code></a>,
+                <a href="#index-aria-slider"><code>slider</code></a>,
+                <a href="#index-aria-spinbutton"><code>spinbutton</code></a>,
+                <a href="#index-aria-switch"><code>switch</code></a>
+                or <a href="#index-aria-textbox"><code>textbox</code></a>. (<code><a href="#index-aria-generic">generic</a></code> is also allowed, but <em class="rfc2119">SHOULD NOT</em> be used.)
+              </p>
+              <p class="addition">
+                <a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-19">Naming Prohibited</a> if exposed as the <code>generic</code> role.
+              </p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-h1-h6" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements"><code>h1 to h6</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-heading">heading</a></code>,
+              <code>aria-level</code> = the number in the element's tag name
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>
+                or <a href="#index-aria-tab"><code>tab</code></a>. (<code><a href="#index-aria-heading">heading</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                DPub Role:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-subtitle"><code>doc-subtitle</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-head" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-head-element">head</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-14">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-14">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-header" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-header-element">header</a></code>
+            </th>
+            <td>
+              <p>
+                If not a descendant of an <code>article</code>, <code>aside</code>, <code>main</code>,
+                <code>nav</code> or <code>section</code> element, or an element with <code>role=article</code>,
+                <code>complementary</code>, <code>main</code>, <code>navigation</code> or <code>region</code> then 
+                <code>role=<a href="#index-aria-banner">banner</a></code>
+              </p>
+              <p>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+              </p>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>
+                or <a href="#index-aria-presentation"><code>presentation</code></a>.
+                (If not a descendant of an <code>article</code>, <code>aside</code>, <code>main</code>, <code>nav</code>
+                or <code>section</code> element, or an element with <code>role=article</code>, <code>complementary</code>,
+                <code>main</code>, <code>navigation</code> or <code>region</code>,
+                then <code>role=<a href="#index-aria-banner">banner</a></code>
+                is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+                is also allowed, but <em class="rfc2119">SHOULD NOT</em> be used.)
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-20">Naming Prohibited</a> if exposed as <code>generic</code>.</p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-hgroup" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-hgroup-element">hgroup</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-group">group</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-18"><strong>Any <code>role</code></strong></a>, though <a href="#index-aria-group"><code>group</code></a> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-hr" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-hr-element">hr</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-separator">separator</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-none"><code>none</code></a>
+                or <a href="#index-aria-presentation"><code>presentation</code></a>. (<code><a href="#index-aria-separator">separator</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                DPub Role:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagebreak"><code>doc-pagebreak</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>separator</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-html" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-html-element">html</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-15"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-document">document</a></code> 
+                or <code><a href="#index-aria-generic">generic</a></code>, which are <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <strong>No <code>aria-*</code> attributes</strong>.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-i" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-i-element">i</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-19"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-21">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-iframe" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">iframe</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-15">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-application"><code>application</code></a>,
+                <a href="#index-aria-document"><code>document</code></a>,
+                <a href="#index-aria-img"><code>img</code></a>,
+                <a href="#index-aria-img"><code>image</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>
+                or <a href="#index-aria-presentation"><code>presentation</code></a>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> and
+                any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-img" tabindex="-1">
+              <div class="correction proposed">
+                <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code>
+              </div>
+            </th>
+            <td>
+              If the <code>img</code> has non-empty <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-alt">alt</a></code> (<code>alt="some text"</code>) or an accessible name is provided by another 
+              <a href="https://www.w3.org/TR/html-aam-1.0/#img-element-accessible-name-computation"><code>img</code> naming method</a>, 
+              or the <code>img</code> has no <code>alt</code> and has not been provided a name:<br>
+              <code>role=<a href="#index-aria-img">img or image</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-button"><code>button</code></a>,
+                <a href="#index-aria-checkbox"><code>checkbox</code></a>,
+                <a href="#index-aria-link"><code>link</code></a>,
+                <span class="correction">
+                  <a href="#index-aria-math"><code>math</code></a>,
+                </span>
+                <a href="#index-aria-menuitem"><code>menuitem</code></a>,
+                <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>,
+                <span class="addition">
+                  <a href="#index-aria-meter"><code>meter</code></a>,
+                </span>
+                <a href="#index-aria-option"><code>option</code></a>,
+                <a href="#index-aria-progressbar"><code>progressbar</code></a>,
+                <span class="correction">
+                  <a href="#index-aria-radio"><code>radio</code></a>,
+                </span>
+                <a href="#index-aria-scrollbar"><code>scrollbar</code></a>,
+                <a href="#index-aria-separator"><code>separator</code></a>,
+                <a href="#index-aria-slider"><code>slider</code></a>,
+                <a href="#index-aria-switch"><code>switch</code></a>,
+                <a href="#index-aria-tab"><code>tab</code></a> or
+                <a href="#index-aria-treeitem"><code>treeitem</code></a>. 
+                (<code><a href="#index-aria-img">img or image</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                DPub Role:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-cover"><code>doc-cover</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-img-no-name" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">img</a></code> with no accessible name
+            </th>
+            <td>
+              <div class="proposed correction">
+                <p id="el-img-empty-alt">
+                  If the <code>img</code> has an empty <code>alt</code> (<code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-alt">alt</a></code><code>=""</code>) and lacks any other 
+                  <a href="https://www.w3.org/TR/html-aam-1.0/#img-element-accessible-name-computation"><code>img</code> naming methods</a>:<br>
+                  <code>role=<a href="#index-aria-none">none</a></code>, 
+                  <code>role=<a href="#index-aria-presentation">presentation</a></code>
+                </p>
+                <p id="el-img-no-alt" tabindex="-1">
+                  If the <code>img</code> <a href="https://html.spec.whatwg.org/multipage/images.html#unknown-images">lacks an <code>alt</code> attribute</a> and lacks any other 
+                  <a href="https://www.w3.org/TR/html-aam-1.0/#img-element-accessible-name-computation"><code>img</code> naming methods</a>:<br>
+                  <code>role=<a href="#index-aria-img">img or image</a></code>
+                </p>
+              </div>
+            </td>
+            <td>
+              <div class="correction proposed">
+              <p>
+                If the <code>img</code> has no <code>alt</code> attribute or accessible name:
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-16"><strong class="nosupport">No <code>role</code></strong></a> other than the  
+                <code>role=<a href="#index-aria-none">none</a></code> or <code><a href="#index-aria-presentation">presentation</a></code> roles.
+                (<code>role=<a href="#index-aria-img">img or image</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                If the <code>img</code> has an empty <code>alt=""</code> attribute and no <code>aria-label</code> or <code>aria-labelledby</code> attributes to provide it an accessible name:
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-17"><strong class="nosupport">No <code>role</code></strong></a> other than the <code>role=<a href="#index-aria-none">none</a></code> or
+                <code><a href="#index-aria-presentation">presentation</a></code> roles, which are <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <strong>No <code>aria-*</code> attributes</strong>
+                except <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden"><code>aria-hidden="true"</code></a>.
+              </p>
+              <p>
+                Otherwise, if the <code>img</code> has an author defined accessible name, 
+                see <a href="#el-img"><code>img</code> with an accessible name</a>.
+              </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-button" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#button-state-(type=button)"><code>input type=button</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-button">button</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <span class="correction"><a href="#index-aria-checkbox"><code>checkbox</code></a>,</span>
+                <span class="addition"><a href="#index-aria-combobox"><code>combobox</code></a>,</span>
+                <span class="proposed addition"><a href="#index-aria-gridcell"><code>gridcell</code></a>,</span>
+                <a href="#index-aria-link"><code>link</code></a>,
+                <a href="#index-aria-menuitem"><code>menuitem</code></a>,
+                <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>,
+                <a href="#index-aria-option"><code>option</code></a>,
+                <a href="#index-aria-radio"><code>radio</code></a>,
+                <span class="proposed addition">
+                  <a href="#index-aria-separator"><code>separator</code></a>,
+                  <a href="#index-aria-slider"><code>slider</code></a>,</span>
+                <a href="#index-aria-switch"><code>switch</code></a>,
+                <a href="#index-aria-tab"><code>tab</code></a>,
+                or <span class="addition proposed"><a href="#index-aria-treeitem"><code>treeitem</code></a></span>. 
+                (<code><a href="#index-aria-button">button</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-checkbox" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)"><code>input type=checkbox</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-checkbox">checkbox</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                <a href="#index-aria-option"><code>option</code></a>
+                or <a href="#index-aria-switch"><code>switch</code></a>;
+                <a href="#index-aria-button"><code>button</code> if used with <code>aria-pressed</code></a>. (<code><a href="#index-aria-checkbox">checkbox</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p class="correction">
+                Authors <a href="#att-checked"><em class="rfc2119">MUST NOT</em> use the <code>aria-checked</code> attribute on <code>input type=checkbox</code> elements</a>.
+              </p>
+              <p>
+                Otherwise, any <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> and
+                any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <div class="note" role="note" id="issue-container-generatedID-1"><div role="heading" class="note-title marker" id="h-note-3" aria-level="3"><span>Note</span></div><p class="">
+                The HTML <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-checked">checked</a></code> attribute can be used instead of
+                the <code>aria-checked</code> attribute for <code>menuitemcheckbox</code>, <code>option</code>
+                or <code>switch</code> roles when used on <code>type=checkbox</code>.
+              </p></div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-color" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#color-state-(type=color)"><code>input type=color</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-16">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-18"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> and <code>aria-disabled</code> attribute.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-date" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#date-state-(type=date)"><code>input type=date</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-17">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-19"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a>
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-datetime-local" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type=datetime-local)"><code>input type=datetime-local</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-18">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-20"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a>
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-email" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)"><code>input type=email</code></a>
+              with no <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-list">list</a></code> attribute
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-textbox">textbox</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-21"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-file" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#file-upload-state-(type=file)"><code>input type=file</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-19">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-22"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a>, 
+                <code>aria-disabled</code>, <code>aria-invalid</code> and <code>aria-required</code> attributes.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-hidden" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#hidden-state-(type=hidden)"><code>input type=hidden</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-20">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-23">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-image" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)"><code>input type=image</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-button">button</a></code>
+            </td>
+            <td>
+              <div class="proposed addition">
+                <p>
+                  The following roles are allowed, but are <em class="rfc2119">NOT RECOMMENDED</em>:
+                  <a href="#index-aria-button"><code>button</code></a>,
+                  <a href="#index-aria-checkbox"><code>checkbox</code></a>,
+                  <a href="#index-aria-gridcell"><code>gridcell</code></a>,
+                  <a href="#index-aria-link"><code>link</code></a>,
+                  <a href="#index-aria-menuitem"><code>menuitem</code></a>,
+                  <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                  <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>,
+                  <a href="#index-aria-option"><code>option</code></a>,
+                  <a href="#index-aria-radio"><code>radio</code></a>,
+                  <a href="#index-aria-separator"><code>separator</code></a>,
+                  <a href="#index-aria-slider"><code>slider</code></a>,
+                  <a href="#index-aria-switch"><code>switch</code></a>,
+                  <a href="#index-aria-tab"><code>tab</code></a>
+                  or <a href="#index-aria-treeitem"><code>treeitem</code></a>. 
+                </p>
+                <p>
+                  <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                  and any <code>aria-*</code> attributes applicable to the allowed roles.
+                </p>
+                <p>
+                  If possible, authors <em class="rfc2119">SHOULD</em> consider using a different HTML element which allows the specified role,
+                  such as the <code>button</code> element.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-month" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#month-state-(type=month)"><code>input type=month</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-21">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-24"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-number" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)"><code>input type=number</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-spinbutton">spinbutton</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-25"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-spinbutton">spinbutton</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>spinbutton</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-password" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#password-state-(type=password)"><code>input type=password</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-22">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-26"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-radio" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)"><code>input type=radio</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-radio">radio</a></code>
+            </td>
+            <td>
+              <p>
+                Role:
+                <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>. (<code><a href="#index-aria-radio">radio</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p class="correction">
+                Authors <a href="#att-checked"><em class="rfc2119">MUST NOT</em> use the
+                <code>aria-checked</code> attribute on <code>input type=radio</code> elements</a>.
+              </p>
+              <p>
+                Otherwise, any <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> and any <code>aria-*</code> attributes
+                applicable to the allowed roles.
+              </p>
+              <div class="note" role="note" id="issue-container-generatedID-2"><div role="heading" class="note-title marker" id="h-note-4" aria-level="3"><span>Note</span></div><p class="">
+                The HTML <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-checked">checked</a></code> attribute can be used instead of
+                the <code>aria-checked</code> attribute for the <code>menuitemradio</code> role
+                when used on <code>type=radio</code>.
+              </p></div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-range" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#range-state-(type=range)"><code>input type=range</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-slider">slider</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-27"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-slider">slider</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Authors <em class="rfc2119">SHOULD NOT</em> use the <a href="#att-max"><code>aria-valuemax</code></a> or 
+                <a href="#att-min"><code>aria-valuemin</code></a> attributes on <code>input type=range</code>.
+              </p>
+              <p>
+                Otherwise, any 
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any other <code>aria-*</code> attributes applicable to the <code>slider</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-reset" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#reset-button-state-(type=reset)"><code>input type=reset</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-button">button</a></code>
+            </td>
+            <td>
+              <div class="proposed addition">
+                <p>
+                  The following roles are allowed, but are <em class="rfc2119">NOT RECOMMENDED</em>:
+                  <a href="#index-aria-button"><code>button</code></a>,
+                  <a href="#index-aria-checkbox"><code>checkbox</code></a>,
+                  <a href="#index-aria-combobox"><code>combobox</code></a>,
+                  <a href="#index-aria-gridcell"><code>gridcell</code></a>,
+                  <a href="#index-aria-link"><code>link</code></a>,
+                  <a href="#index-aria-menuitem"><code>menuitem</code></a>,
+                  <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                  <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>,
+                  <a href="#index-aria-option"><code>option</code></a>,
+                  <a href="#index-aria-radio"><code>radio</code></a>,
+                  <a href="#index-aria-separator"><code>separator</code></a>,
+                  <a href="#index-aria-slider"><code>slider</code></a>,
+                  <a href="#index-aria-switch"><code>switch</code></a>,
+                  <a href="#index-aria-tab"><code>tab</code></a>
+                  or <a href="#index-aria-treeitem"><code>treeitem</code></a>.
+                </p>
+                <p>
+                  <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                  and any <code>aria-*</code> attributes applicable to the allowed roles.
+                </p>
+                <p>
+                  If possible, authors <em class="rfc2119">SHOULD</em> consider using a different HTML element which allows the specified role,
+                  such as the <code>button</code> element.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-search" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"><code>input type=search</code></a>,
+              with no <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-list">list</a></code> attribute
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-searchbox">searchbox</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-28"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-searchbox">searchbox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>searchbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-submit" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#submit-button-state-(type=submit)"><code>input type=submit</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-button">button</a></code>
+            </td>
+            <td>
+              <div class="proposed addition">
+                <p>
+                  The following roles are allowed, but are <em class="rfc2119">NOT RECOMMENDED</em>:
+                  <a href="#index-aria-button"><code>button</code></a>,
+                  <a href="#index-aria-checkbox"><code>checkbox</code></a>,
+                  <a href="#index-aria-combobox"><code>combobox</code></a>,
+                  <a href="#index-aria-gridcell"><code>gridcell</code></a>,
+                  <a href="#index-aria-link"><code>link</code></a>,
+                  <a href="#index-aria-menuitem"><code>menuitem</code></a>,
+                  <a href="#index-aria-menuitemcheckbox"><code>menuitemcheckbox</code></a>,
+                  <a href="#index-aria-menuitemradio"><code>menuitemradio</code></a>,
+                  <a href="#index-aria-option"><code>option</code></a>,
+                  <a href="#index-aria-radio"><code>radio</code></a>,
+                  <a href="#index-aria-separator"><code>separator</code></a>,
+                  <a href="#index-aria-slider"><code>slider</code></a>,
+                  <a href="#index-aria-switch"><code>switch</code></a>,
+                  <a href="#index-aria-tab"><code>tab</code></a>
+                  or <a href="#index-aria-treeitem"><code>treeitem</code></a>.
+                </p>
+                <p>
+                  <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                  and any <code>aria-*</code> attributes applicable to the allowed roles.
+                </p>
+                <p>
+                  If possible, authors <em class="rfc2119">SHOULD</em> consider using a different HTML element which allows the specified role,
+                  such as the <code>button</code> element.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-tel" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#telephone-state-(type=tel)"><code>input type=tel</code></a>, 
+              with no <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-list">list</a></code> attribute
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-textbox">textbox</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-29"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-text" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"><code>input type=text</code></a>
+              or with a missing or invalid <code>type</code>, with no <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-list">list</a></code> attribute
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-textbox">textbox</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-combobox"><code>combobox</code></a>,
+                <a href="#index-aria-searchbox"><code>searchbox</code></a>
+                or <a href="#index-aria-spinbutton"><code>spinbutton</code></a>. (<code><a href="#index-aria-textbox">textbox</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-text-list" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"><code>input type=text</code></a>,
+              <a href="https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)"><code>search</code></a>,
+              <a href="https://html.spec.whatwg.org/multipage/input.html#telephone-state-(type=tel)"><code>tel</code></a>,
+              <a href="https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)"><code>url</code></a>,
+              <a href="https://html.spec.whatwg.org/multipage/input.html#e-mail-state-(type=email)"><code>email</code></a>,
+              or with a missing or invalid <code>type</code>, <strong>with a <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-list">list</a></code> attribute</strong>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-combobox">combobox</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-30"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-combobox">combobox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-haspopup</code> attribute on the indicated <code>input</code>s with a <code>list</code> attribute.
+              </p>
+              <p>
+                Otherwise, any
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any other <code>aria-*</code> attributes applicable to the <code>combobox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-time" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time)"><code>input type=time</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-23">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-31"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-url" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)"><code>input type=url</code></a>
+              with no <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-list">list</a></code> attribute
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-textbox">textbox</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-32"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-input-week" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/input.html#week-state-(type=week)"><code>input type=week</code></a>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-24">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-33"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-ins" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/edits.html#the-ins-element">ins</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-insertion"><code>insertion</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-20"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-insertion"><code>insertion</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-22">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-kbd" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-kbd-element">kbd</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-25">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-21"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-23">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-label" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-label-element">label</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-26">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                If a <code>label</code> element is implicitly or explicitly associated with a 
+                <a href="https://html.spec.whatwg.org/multipage/forms.html#category-label">labelable element</a> then
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-34"><strong class="nosupport">no <code>role</code></strong></a>
+              </p>
+              <p>
+                Otherwise, if the <code>label</code> is not associted with an element then <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-22"><strong>any <code>role</code></strong></a>, 
+                though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-24">Naming Prohibited</a> if exposed as the <code>generic</code> role, or if exposed as another role which prohibits naming.</p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a>.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-legend" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-legend-element">legend</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-27">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-35"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-25">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a>.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-li" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element">li</a></code>
+            </th>
+            <td>
+              <p>
+                If the <code>li</code> is a child of a list element 
+                (<a href="#el-ul"><code>ul</code></a>, <a href="#el-ol"><code>ol</code></a>, 
+                <a href="#el-menu"><code>menu</code></a>)
+                <code>role=<a href="#index-aria-listitem">listitem</a></code>.
+              </p>
+              <p>
+                Otherwise, if the <code>li</code> is not a child of a list element it is exposed as 
+                a <code>role=<a href="#index-aria-generic">generic</a></code>.
+              </p>
+            </td>
+            <td>
+              <div class="proposed correction">
+                <p>
+                  <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-36">No <code>role</code></a></strong> other than <code><a href="#index-aria-listitem">listitem</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>,
+                  if the parent list element has an implicit or explicit <code>list</code> role.
+                </p>
+                <p>
+                  Otherwise, <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-23"><strong>any <code>role</code></strong></a> if the parent list element does not expose an implicit or explicit <code>list</code> role.
+                </p>
+                <div class="note" role="note" id="issue-container-generatedID-3"><div role="heading" class="note-title marker" id="h-note-5" aria-level="3"><span>Note</span></div><p class="">
+                  See <a href="#el-ul"><code>ul</code></a>, <a href="#el-ol"><code>ol</code></a>, or
+                  <a href="#el-menu"><code>menu</code></a> for allowed roles for list elements.
+                </p></div>
+              </div>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <div class="addition proposal">
+                <p>Authors <em class="rfc2119">SHOULD NOT</em> use the following <a href="#docconformance-deprecated">deprecated</a> DPub Roles:
+                  <a href="https://www.w3.org/TR/dpub-aria-1.1/#doc-biblioentry"><code>doc-biblioentry</code></a>,
+                  <a href="https://www.w3.org/TR/dpub-aria-1.1/#doc-endnote"><code>doc-endnote</code></a>.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-link" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">link</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-28">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-37">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-main" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-main">main</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-38"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-main">main</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>main</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-map" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/image-maps.html#the-map-element">map</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-29">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-39">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-mark" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element">mark</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-30">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-24"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-26">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-math" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#mathml"><code>math</code></a>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-math">math</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-40"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-math">math</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>math</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-menu" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#menus">menu</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-list">list</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-listbox"><code>listbox</code></a>,
+                <a href="#index-aria-menu"><code>menu</code></a>,
+                <a href="#index-aria-menubar"><code>menubar</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>,
+                <a href="#index-aria-radiogroup"><code>radiogroup</code></a>,
+                <a href="#index-aria-tablist"><code>tablist</code></a>,
+                <a href="#index-aria-toolbar"><code>toolbar</code></a>
+                or <a href="#index-aria-tree"><code>tree</code></a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <div class="addition proposal">
+                <p>Authors <em class="rfc2119">SHOULD NOT</em> use <a href="#docconformance-deprecated">deprecated</a> <a href="#index-aria-directory"><code>directory</code></a> role.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-meta" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta">meta</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-31">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-41">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-meter" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element">meter</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-meter"><code>meter</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-42"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-meter"><code>meter</code></a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Authors <em class="rfc2119">SHOULD NOT</em> use the <a href="#att-max"><code>aria-valuemax</code></a> or 
+                <a href="#att-min"><code>aria-valuemin</code></a> attributes on <code>meter</code> elements.
+              </p>
+              <p>
+                Otherwise, any 
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a>
+                and any other <code>aria-*</code> attributes applicable to the <code>meter</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-nav" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-nav-element">nav</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-navigation">navigation</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-menu"><code>menu</code></a>,
+                <a href="#index-aria-menubar"><code>menubar</code></a>,
+                <span class="addition"><a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a></span>
+                or <a href="#index-aria-tablist"><code>tablist</code></a>. (<code><a href="#index-aria-navigation">navigation</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                DPub Roles:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-index"><code>doc-index</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist"><code>doc-pagelist</code></a>
+                or <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-toc"><code>doc-toc</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-noscript" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-noscript-element">noscript</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-32">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-43">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-object" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">object</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-33">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-application"><code>application</code></a>,
+                <a href="#index-aria-document"><code>document</code></a>,
+                <a href="#index-aria-img"><code>img</code></a>
+                or <a href="#index-aria-img"><code>image</code></a>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> and
+                any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-ol" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ol-element">ol</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-list">list</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-listbox"><code>listbox</code></a>,
+                <a href="#index-aria-menu"><code>menu</code></a>,
+                <a href="#index-aria-menubar"><code>menubar</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>,
+                <a href="#index-aria-radiogroup"><code>radiogroup</code></a>,
+                <a href="#index-aria-tablist"><code>tablist</code></a>,
+                <a href="#index-aria-toolbar"><code>toolbar</code></a>
+                or <a href="#index-aria-tree"><code>tree</code></a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <div class="addition proposal">
+                <p>Authors <em class="rfc2119">SHOULD NOT</em> use <a href="#docconformance-deprecated">deprecated</a> <a href="#index-aria-directory"><code>directory</code></a> role.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-optgroup" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-optgroup-element">optgroup</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-group">group</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-44"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-group">group</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>group</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-option" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-option-element">option</a></code> element that is in a <a href="https://html.spec.whatwg.org/multipage/input.html#attr-input-list">list of options</a> or that
+              represents a suggestion in a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element">datalist</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-option">option</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-45"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-option">option</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-selected</code> attribute on the <code>option</code> element.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> and
+                any other <code>aria-*</code> attributes applicable to the <code>option</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-output" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-output-element">output</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-status">status</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-25"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-status">status</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-p" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element">p</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-paragraph"><code>paragraph</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-26"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-paragraph"><code>paragraph</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-27">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-param" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/obsolete.html#param">param</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-34">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-46">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-picture" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element">picture</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-35">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-47"><strong class="nosupport">No <code>role</code></strong></a>
+              </p>
+              <div class="addition">
+                <p>
+                  Authors <em class="rfc2119">MAY</em> specify the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden"><code>aria-hidden</code></a> attribute on the <code>picture</code> element.
+                  Otherwise, no other allowed <code>aria-*</code> attributes.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-pre" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-pre-element">pre</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-27"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-28">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-progress" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">progress</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-progressbar">progressbar</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-48"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-progressbar">progressbar</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Authors <em class="rfc2119">SHOULD NOT</em> use the <a href="#att-max"><code>aria-valuemax</code></a> attribute 
+                on <code>progress</code> elements.
+              </p>
+              <p>
+                Otherwise, 
+                any <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any other <code>aria-*</code> attributes applicable to the <code>progressbar</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-q" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-q-element">q</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-28"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-29">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-rp" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rp-element">rp</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-36">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-29"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-30">Naming Prohibited</a></p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-rt" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-rt-element">rt</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-37">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-30"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-31">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-ruby" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-ruby-element">ruby</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-38">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-31"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-s" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-s-element">s</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-deletion"><code>deletion</code></a></code>
+            </td>
+            <td>
+              <p class="proposed addition">
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-32"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-deletion"><code>deletion</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-32">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-samp" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-samp-element">samp</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-33"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-33">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-script" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#script">script</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-39">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-49">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-search" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element">search</a></code>
+            </th>
+            <td>
+              <p>
+                <code>role=<a href="#index-aria-search">search</a></code>
+              </p>
+            </td>
+            <td>
+              <div class="addition proposed">
+                <p>
+                  Roles:
+                  <a href="#index-aria-form"><code>form</code></a>,
+                  <a href="#index-aria-group"><code>group</code></a>,
+                  <a href="#index-aria-none"><code>none</code></a>,
+                  <a href="#index-aria-presentation"><code>presentation</code></a> or
+                  <a href="#index-aria-region"><code>region</code></a>.
+                  (<code><a href="#index-aria-search">search</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+                </p>
+                <p>
+                  <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                  and any <code>aria-*</code> attributes applicable to the allowed roles.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-section" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element">section</a></code>
+            </th>
+            <td>
+              <p>
+                <code>role=<a href="#index-aria-region">region</a></code> if the
+                <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-section-element">section</a></code> element has an 
+                <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible name</a>
+              </p> 
+              <p>
+                Otherwise, <code>role=<a href="#index-aria-generic">generic</a></code>
+              </p>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-alert"><code>alert</code></a>,
+                <a href="#index-aria-alertdialog"><code>alertdialog</code></a>,
+                <a href="#index-aria-application"><code>application</code></a>,
+                <a href="#index-aria-banner"><code>banner</code></a>,
+                <a href="#index-aria-complementary"><code>complementary</code></a>,
+                <a href="#index-aria-contentinfo"><code>contentinfo</code></a>,
+                <a href="#index-aria-dialog"><code>dialog</code></a>,
+                <a href="#index-aria-document"><code>document</code></a>,
+                <a href="#index-aria-feed"><code>feed</code></a>,
+                <span class="addition"><a href="#index-aria-group"><code>group</code></a>,</span>
+                <a href="#index-aria-log"><code>log</code></a>,
+                <a href="#index-aria-main"><code>main</code></a>,
+                <a href="#index-aria-marquee"><code>marquee</code></a>,
+                <a href="#index-aria-navigation"><code>navigation</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-note"><code>note</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>,
+                <a href="#index-aria-search"><code>search</code></a>,
+                <a href="#index-aria-status"><code>status</code></a>
+                or <a href="#index-aria-tabpanel"><code>tabpanel</code></a>.
+                (<code>role=<a href="#index-aria-region">region</a></code> is also allowed, 
+                but <em class="rfc2119">NOT RECOMMENDED</em>. <code>role=<a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.)
+              </p>
+              <p>
+                DPub Roles:
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-abstract"><code>doc-abstract</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-acknowledgments"><code>doc-acknowledgments</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-afterword"><code>doc-afterword</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-appendix"><code>doc-appendix</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-bibliography"><code>doc-bibliography</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-chapter"><code>doc-chapter</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-colophon"><code>doc-colophon</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-conclusion"><code>doc-conclusion</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credit"><code>doc-credit</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-credits"><code>doc-credits</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-dedication"><code>doc-dedication</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-endnotes"><code>doc-endnotes</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epigraph"><code>doc-epigraph</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-epilogue"><code>doc-epilogue</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-errata"><code>doc-errata</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-example"><code>doc-example</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-foreword"><code>doc-foreword</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-glossary"><code>doc-glossary</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-index"><code>doc-index</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-introduction"><code>doc-introduction</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-notice"><code>doc-notice</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pagelist"><code>doc-pagelist</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-part"><code>doc-part</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-preface"><code>doc-preface</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-prologue"><code>doc-prologue</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-pullquote"><code>doc-pullquote</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-qna"><code>doc-qna</code></a>,
+                <a href="https://www.w3.org/TR/dpub-aria-1.0/#doc-toc"><code>doc-toc</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-select" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">select</a></code> (with NO <code>multiple</code> attribute and NO <code>size</code>
+              attribute having value greater than <code>1</code>)
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-combobox">combobox</a></code>
+            </td>
+            <td>
+              <p>
+                Role: <a href="#index-aria-menu"><code>menu</code></a>. (<code><a href="#index-aria-combobox">combobox</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-multiselectable</code> attribute on a <code>select</code> element.
+              </p>
+              <p>
+                Otherwise, 
+                any <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any other <code>aria-*</code> attributes applicable to the <code>combobox</code> or <code>menu</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-select-multiple-or-size-greater-1" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element">select</a></code> (with a <code>multiple</code> attribute or a <code>size</code> attribute
+              having value greater than <code>1</code>)
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-list">listbox</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-50"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-list">listbox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-multiselectable</code> attribute on a <code>select</code> element.
+              </p>
+              <p>
+                Otherwise, 
+                any <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any other <code>aria-*</code> attributes applicable to the <code>listbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-selectedcontent" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-selectedcontent-element">selectedcontent</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                If used as a valid descendant of a <code>select</code> element: <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-51">no <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+              <p>
+                Otherwise, <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-34"><strong>any <code>role</code></strong></a> if the element is used outside of its intended context as a child of the <code>button</code> part of a customizable <code>select</code> element, 
+                though <code><a href="#index-aria-generic">generic</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-34">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-slot" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">slot</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-40">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-52">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-small" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-small-element">small</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-35"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-35">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-source" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">source</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-41">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-53">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-span" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">span</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-36"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-36">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-strong" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-strong-element">strong</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-strong"><code>strong</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-37"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-strong"><code>strong</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-37">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-style" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">style</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-42">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-54">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-sub" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-element">sub</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-subscript"><code>subscript</code></a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-38"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-subscript"><code>subscript</code></a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-38">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-summary" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-summary-element">summary</a></code>
+            </th>
+            <td>
+              <p>
+                <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-43">No corresponding role</a>
+              </p>
+              <div class="note" role="note" id="issue-container-generatedID-4"><div role="heading" class="note-title marker" id="h-note-6" aria-level="3"><span>Note</span></div><div class="">
+                Many, but not all, user agents expose the <code>summary</code> element with an implicit ARIA 
+                <code>role=<a href="#index-aria-button">button</a></code>.
+              </div></div>
+            </td>
+            <td>
+              <div class="proposed correction">
+                <p>
+                  <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-55"><strong class="nosupport">No <code>role</code></strong></a> if the <code>summary</code> element is a 
+                  <a href="https://html.spec.whatwg.org/multipage/interactive-elements.html#summary-for-its-parent-details">summary for its parent details</a>.
+                </p>
+                <p>
+                  <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a>, 
+                  <code>aria-disabled</code>, and <code>aria-haspopup</code> attributes.
+                </p>
+                <p>
+                  Otherwise, authors <em class="rfc2119">MAY</em> specifiy <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-39"><strong>Any <code>role</code></strong></a>, and any 
+                  <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                  and any <code>aria-*</code> attributes applicable to the allowed roles.
+                </p>
+               </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-sup" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sup-element">sup</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-superscript">superscript</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-40"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-superscript">superscript</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-39">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-svg" tabindex="-1">
+              <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#svg-0"><code>SVG</code></a>
+            </th>
+            <td>
+              <code>role=graphics-document</code> as defined by
+              <a href="https://www.w3.org/TR/svg-aam-1.0/#details-id-66">SVG AAM</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-41"><strong>Any <code>role</code></strong></a>, though <code>graphics-document</code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-table" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-table-element">table</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-table">table</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-42"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-table">table</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-tbody" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-tbody-element">tbody</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-43"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-td" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-td-element">td</a></code>
+            </th>
+            <td>
+              <p>
+                <code>role=<a href="#index-aria-cell">cell</a></code> if the ancestor
+                <code>table</code> element is exposed as a <code>role=table</code>
+              </p>
+              <p>
+                <code>role=<a href="#index-aria-gridcell">gridcell</a></code> if the ancestor
+                <code>table</code> element is exposed as a <code>role=grid</code> or <code>treegrid</code>
+              </p>
+              <p>
+                <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-44">No corresponding role</a> if the ancestor <code>table</code> element is not exposed
+                as a <code>role=table</code>, <code>grid</code> or <code>treegrid</code>
+              </p>
+            </td>
+            <td>
+              <p>
+                If the ancestor <code>table</code> element has <code>role=table</code>, <code>grid</code>, or <code>treegrid</code>,
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-56"><strong class="nosupport">no <code>role</code></strong></a>
+                other than the following:
+              </p>
+              <ul>
+                <li>If the ancestor <code>table</code> element is exposed as a <code>role=table</code>, then
+                <code><a href="#index-aria-cell">cell</a></code>
+                is allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.</li>
+                <li>If the ancestor <code>table</code> element is exposed as a <code>role=grid</code> or <code>treegrid</code>, then
+                <code><a href="#index-aria-gridcell">gridcell</a></code>
+                is allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.</li>
+              </ul>
+              <p>
+                Otherwise, if the ancestor <code>table</code> element is not exposed
+                as a <code>role=table</code>, <code>grid</code> or <code>treegrid</code>,
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-44"><strong>any <code>role</code></strong></a>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-template" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">template</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-45">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-57">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-textarea" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element">textarea</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-textbox">textbox</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-58"><strong class="nosupport">No <code>role</code></strong></a> other than <code><a href="#index-aria-textbox">textbox</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>textbox</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-tfoot" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-tfoot-element">tfoot</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-45"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-th" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-th-element">th</a></code>
+            </th>
+            <td>
+              <p>
+                <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader"><code>rowheader</code></a> or 
+                <a href="#index-aria-rowheader"><code>cell</code></a> if the ancestor
+                <code>table</code> element is exposed as a <code>role=table</code>
+              </p>
+              <p>
+                <code>role=<a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader"><code>rowheader</code></a> or 
+                <a href="#index-aria-rowheader"><code>gridcell</code></a> if the ancestor
+                <code>table</code> element is exposed as a <code>role=grid</code> or <code>treegrid</code>
+             </p>
+              <p>
+                <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-46">No corresponding role</a> if the ancestor <code>table</code> element is not exposed
+                as a <code>role=table</code>, <code>grid</code> or <code>treegrid</code>
+              </p>
+            </td>
+            <td>
+              <p>
+                If the ancestor <code>table</code> element has <code>role=table</code>, <code>grid</code>, or <code>treegrid</code>,
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-59"><strong class="nosupport">no <code>role</code></strong></a>
+                other than the following:
+              </p>
+              <ul>
+                <li>
+                If the ancestor <code>table</code> element is exposed as a <code>role=table</code>, then
+                <code><a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader"><code>rowheader</code></a> and
+                <a href="#index-aria-rowheader"><code>cell</code></a>
+                are allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.
+                </li>
+                <li>
+                If the ancestor <code>table</code> element is exposed as a <code>role=grid</code> or <code>treegrid</code>, then
+                <code><a href="#index-aria-columnheader">columnheader</a></code>,
+                <a href="#index-aria-rowheader"><code>rowheader</code></a> or
+                <a href="#index-aria-rowheader"><code>gridcell</code></a>
+                are allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.
+                </li>
+              </ul>
+              <p>
+                Otherwise, if the ancestor <code>table</code> element is not exposed
+                as a <code>role=table</code>, <code>grid</code> or <code>treegrid</code>,
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-46"><strong>any <code>role</code></strong></a>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-thead" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-thead-element">thead</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-rowgroup">rowgroup</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-47"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-rowgroup">rowgroup</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-time" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-time-element">time</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-time">time</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-48"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-time">time</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-40">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-title" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#the-title-element">title</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-47">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-60">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-tr" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-tr-element">tr</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-row">row</a></code>
+            </td>
+            <td>
+              <p>
+                If the ancestor <code>table</code> element has <code>role=table</code>, <code>grid</code>, or <code>treegrid</code>,
+                <a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-61"><strong class="nosupport">no <code>role</code></strong></a> other than <code><a href="#index-aria-row">row</a></code>, which is <em class="rfc2119">NOT RECOMMENDED</em>;
+                otherwise
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-49"><strong>any <code>role</code></strong></a>, though <code><a href="#index-aria-row">row</a></code> is <em class="rfc2119">NOT RECOMMENDED</em>.
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-track" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">track</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-48">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <strong class="nosupport"><a href="#dfn-no-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-role-62">No <code>role</code></a> or <code>aria-*</code> attributes</strong>
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-u" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-u-element">u</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-generic">generic</a></code>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-50"><strong>Any <code>role</code></strong></a>, though <code><a href="#index-aria-generic">generic</a></code> <em class="rfc2119">SHOULD NOT</em> be used.
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-41">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-ul" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-ul-element">ul</a></code>
+            </th>
+            <td>
+              <code>role=<a href="#index-aria-list">list</a></code>
+            </td>
+            <td>
+              <p>
+                Roles:
+                <a href="#index-aria-group"><code>group</code></a>,
+                <a href="#index-aria-listbox"><code>listbox</code></a>,
+                <a href="#index-aria-menu"><code>menu</code></a>,
+                <a href="#index-aria-menubar"><code>menubar</code></a>,
+                <a href="#index-aria-none"><code>none</code></a>,
+                <a href="#index-aria-presentation"><code>presentation</code></a>,
+                <a href="#index-aria-radiogroup"><code>radiogroup</code></a>,
+                <a href="#index-aria-tablist"><code>tablist</code></a>,
+                <a href="#index-aria-toolbar"><code>toolbar</code></a>
+                or <a href="#index-aria-tree"><code>tree</code></a>. (<code><a href="#index-aria-list">list</a></code> is also allowed, but <em class="rfc2119">NOT RECOMMENDED</em>.)
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+              <div class="addition proposal">
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use the <a href="#docconformance-deprecated">deprecated</a> 
+                  <a href="#index-aria-directory"><code>directory</code></a> role.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-var" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-var-element">var</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-49">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                <a href="#dfn-any-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-any-role-51"><strong>Any <code>role</code></strong></a>
+              </p>
+              <p class="addition"><a href="#dfn-naming-prohibited" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-naming-prohibited-42">Naming Prohibited</a></p>
+              <p>
+                Otherwise, <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the allowed roles.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-video" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/media.html#video">video</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-50">No corresponding role</a>
+            </td>
+            <td>
+              <p>
+                Role: <a href="#index-aria-application"><code>application</code></a>
+              </p>
+              <p>
+                <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">Global <code>aria-*</code> attributes</a> 
+                and any <code>aria-*</code> attributes applicable to the <code>application</code> role.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <th id="el-wbr" tabindex="-1">
+              <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-wbr-element">wbr</a></code>
+            </th>
+            <td>
+              <a href="#dfn-no-corresponding-role" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-no-corresponding-role-51">No corresponding role</a>
+            </td>
+            <td>
+              <div class="correction">
+                <p>
+                  Roles:
+                  <a href="#index-aria-none"><code>none</code></a>
+                  or <a href="#index-aria-presentation"><code>presentation</code></a>
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> specify the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden"><code>aria-hidden</code></a> attribute on the <code>wbr</code> element.
+                  Otherwise, no other allowed <code>aria-*</code> attributes.
+                </p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        The elements marked with <dfn id="dfn-no-corresponding-role" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">No corresponding role</dfn>, in the second column of 
+        the table do not have any <a data-link-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a>, but they do have meaning 
+        and this meaning may be represented in roles, states and properties not provided 
+        by ARIA, and exposed to users of assistive technology via accessibility APIs. 
+        It is therefore recommended that authors add a <code>role</code> attribute to a semantically 
+        neutral element such as a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-div-element">div</a></code> or <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element">span</a></code>, rather than overriding the semantics 
+        of the listed elements.
+      </p>
+      <div class="note" role="note" id="issue-container-generatedID-5"><div role="heading" class="note-title marker" id="h-note-7" aria-level="3"><span>Note</span></div><div class="">
+        <p>
+          Authors are encouraged to make use of the following documents for
+          guidance on using ARIA in HTML beyond that which is provided here:
+        </p>
+        <ul>
+          <li><cite><a data-matched-text="[[[using-aria]]]" href="https://www.w3.org/TR/using-aria/">Using ARIA</a></cite> - A practical guide for authors on how to
+          add accessibility information to HTML elements using the Accessible
+          Rich Internet Applications specification.
+          </li>
+          <li><cite><a data-matched-text="[[[wai-aria-practices-1.2]]]" href="https://www.w3.org/TR/wai-aria-practices-1.2/">WAI-ARIA Authoring Practices 1.2</a></cite> - An author's guide to
+            understanding and implementing Accessible Rich Internet Applications.
+          </li>
+        </ul>
+      </div></div>
+      <aside class="example" id="example-13"><div class="marker">
+    <a class="self-link" href="#example-13">Example<bdi> 13</bdi></a>
+  </div>
+        <p>
+          These features can be used to make accessibility tools render content
+          to their users in more useful ways. For example, ASCII art, which is
+          really an image, appears to be text, and in the absence of
+          appropriate roles and properties would end up being rendered by
+          screen readers as a nonsensical string of punctuation characters.
+          Using the features described in this section, one can instead make
+          the ATs skip the ASCII art and just read the caption:
+        </p>
+        <pre aria-busy="false"><code class="hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">figure</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">pre</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"img"</span> <span class="hljs-attr">aria-label</span>=<span class="hljs-string">"ASCII Fish"</span>&gt;</span>
+  o           .'`/
+    '      /  (
+  O    .-'` ` `'-._      .')
+      _/ (o)        '.  .' /
+      )       )))     &gt;&lt;  &lt;
+      `\  |_\      _.'  '. \
+        '-._  _ .-'       '.)
+    jgs     `\__\
+  <span class="hljs-tag">&lt;/<span class="hljs-name">pre</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">figcaption</span> <span class="hljs-attr">id</span>=<span class="hljs-string">"fish-caption"</span>&gt;</span>
+    Joan G. Stark, "<span class="hljs-tag">&lt;<span class="hljs-name">cite</span>&gt;</span>fish<span class="hljs-tag">&lt;/<span class="hljs-name">cite</span>&gt;</span>".
+    October 1997. ASCII on electrons. 28×8.
+  <span class="hljs-tag">&lt;/<span class="hljs-name">figcaption</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">figure</span>&gt;</span></code></pre>
+      </aside>
+      <section class="addition" id="requirements-for-use-of-aria-attributes-to-name-elements"><div class="header-wrapper"><h3 id="docconformance-naming"><bdi class="secno">4.1 </bdi>
+          Requirements for use of ARIA attributes to name  elements
+        </h3><a class="self-link" href="#docconformance-naming" aria-label="Permalink for Section 4.1"></a></div>
+        
+        
+          <p>
+            Authors <em class="rfc2119">MAY</em> use <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-label"><code>aria-label</code></a> and <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-labelledby"><code>aria-labelledby</code></a> attributes to specify <a href="https://www.w3.org/TR/accname-1.2/#dfn-accessible-name">accessible names</a> for elements which have an implicit or explicit ARIA role which allows naming from authors. <cite><a data-matched-text="[[[wai-aria-1.2]]]" href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> defines <a href="https://www.w3.org/TR/wai-aria-1.2/#namefromauthor">roles which allow naming from authors</a> as well as <a href="https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited">roles where author naming is prohibited</a>.
+          </p>
+          <p>
+            Authors <em class="rfc2119">MUST NOT</em> specify <code>aria-label</code> or <code>aria-labelledby</code> on elements with implicit WAI-ARIA roles which cannot be named. HTML elements whose implicit WAI-ARIA roles prohibit naming from authors are identified in <a href="#docconformance" data-matched-text="[[[#docconformance]]]" class="sec-ref"><bdi class="secno">4. </bdi>
+        Document conformance requirements for use of ARIA attributes in HTML</a>.
+          </p>
+          <p>
+            The following markup example demonstrates a selection of HTML elements with implicit ARIA roles that prohibit naming from authors.
+          </p>
+          <div class="example" id="example-elements-with-implicit-aria-roles-which-prohibit-naming-from-authors">
+        <div class="marker">
+    <a class="self-link" href="#example-elements-with-implicit-aria-roles-which-prohibit-naming-from-authors">Example<bdi> 14</bdi></a><span class="example-title">: Elements with implicit ARIA roles which prohibit naming from authors</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-comment">&lt;!-- DO NOT do the following! --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">p</span> <span class="hljs-attr">aria-label</span>=<span class="hljs-string">"..."</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">span</span> <span class="hljs-attr">aria-label</span>=<span class="hljs-string">"..."</span>&gt;</span>...<span class="hljs-tag">&lt;<span class="hljs-name">span</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">code</span> <span class="hljs-attr">aria-label</span>=<span class="hljs-string">"..."</span>&gt;</span>...<span class="hljs-tag">&lt;<span class="hljs-name">code</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">aria-labelledby</span>=<span class="hljs-string">"..."</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></code></pre>
+      </div>
+          <p>
+            The following markup example demonstrates elements which have explicit WAI-ARIA roles which allow naming from authors. Due to the explicit roles specified on these elements, <code>aria-label</code> and <code>aria-labelledby</code> attributes are allowed.
+          </p>
+          <div class="example" id="example-elements-with-explicit-aria-roles-which-allow-naming-from-authors">
+        <div class="marker">
+    <a class="self-link" href="#example-elements-with-explicit-aria-roles-which-allow-naming-from-authors">Example<bdi> 15</bdi></a><span class="example-title">: Elements with explicit ARIA roles which allow naming from authors</span>
+  </div> <pre class="HTML" aria-busy="false"><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">p</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"link"</span> <span class="hljs-attr">tabindex</span>=<span class="hljs-string">"0"</span> <span class="hljs-attr">aria-label</span>=<span class="hljs-string">"..."</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">p</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">span</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"button"</span> <span class="hljs-attr">tabindex</span>=<span class="hljs-string">"0"</span> <span class="hljs-attr">aria-label</span>=<span class="hljs-string">"..."</span>&gt;</span>...<span class="hljs-tag">&lt;<span class="hljs-name">span</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"article"</span> <span class="hljs-attr">aria-labelledby</span>=<span class="hljs-string">"..."</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></code></pre>
+      </div>
+        
+      </section>
+      <section id="requirements-for-use-of-aria-attributes-in-place-of-equivalent-html-attributes"><div class="header-wrapper"><h3 id="docconformance-attr"><bdi class="secno">4.2 </bdi>
+          Requirements for use of ARIA attributes in place of equivalent HTML attributes
+        </h3><a class="self-link" href="#docconformance-attr" aria-label="Permalink for Section 4.2"></a></div>
+        
+        <p>
+          Unless otherwise stated, authors <em class="rfc2119">MAY</em> use <code>aria-*</code> attributes in place of their HTML equivalents on HTML elements where the <code>aria-*</code> semantics would 
+          be expected. For example, authors <em class="rfc2119">MAY</em> specify <code>aria-disabled=true</code> on a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">button</a></code> element, while also implementing the necessary scripting to functionally 
+          disable the <code>button</code>, rather than the use <code>disabled</code> attribute.
+        </p>
+        <p>
+          As stated in <a href="https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict">WAI-ARIA's Conflicts with Host Language Semantics</a>,
+          when HTML elements use <em>both</em> <code>aria-*</code> attributes and their host language (HTML) equivalents, user agents <em class="rfc2119">MUST</em> ignore the WAI-ARIA attributes – the 
+          native HTML attributes with the same <a data-link-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a> take precedence. For this reason, authors <em class="rfc2119">SHOULD NOT</em> specify both the native HTML attribute 
+          and the equivalent <code>aria-*</code> attribute on an element. Please review each attribute for any further author specific requirements.
+        </p>
+        <p>
+          The following table represents HTML elements and their attributes which have <code>aria-*</code> attribute parity.
+        </p>
+        <p>
+          Each language feature (element and attribute) in a cell in the first
+          column implies the ARIA semantics (states, and properties) given in
+          the cell in the second column of the same row. The third cell in each
+          row defines how authors can use the native HTML feature, along with
+          requirements for using the <code>aria-*</code> attributes that supply the same
+          <a data-link-type="dfn" href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a>.
+        </p>
+        <table class="data">
+          <caption>
+            Rules of ARIA attribute usage by HTML feature
+          </caption>
+          <thead>
+            <tr>
+              <th>
+                HTML feature
+              </th>
+              <th>
+                <p id="implicit-attr">
+                  Implicit ARIA semantics
+                </p>
+              </th>
+              <th>
+                HTML feature and <code>aria-*</code> attribute author guidance
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="att-checked" tabindex="-1">
+              <th>
+                Any element where the <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-checked">checked</a></code> attribute is allowed
+              </th>
+              <td>
+                <code>aria-checked="true"</code>
+              </td>
+              <td>
+                <div class="correction">
+                  <p>
+                    Use the <code>checked</code> attribute on any element that is allowed the <code>checked</code> attribute in HTML. 
+                    Use the <a href="https://html.spec.whatwg.org/multipage/input.html#dom-input-indeterminate"><code>indeterminate</code></a> IDL attribute to indicate the "mixed" state for <a href="https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)"><code>input type=checkbox</code></a> elements.
+                  </p>
+                  <p>
+                    Authors <em class="rfc2119">MUST NOT</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-checked"><code>aria-checked</code></a> attribute on any element where the <a href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-checked">checkedness</a>, or the 
+                    indeterminate checked value of the element can be in opposition to the current value of the <code>aria-checked</code> attribute.
+                  </p>
+                </div>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <code>aria-checked</code> attribute on any other element with a WAI-ARIA role which allows the attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-disabled" tabindex="-1">
+              <th>
+                Any element where the <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled">disabled</a></code>
+                attribute is allowed, including
+                <code>option</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-option-disabled">disabled</a></code> and
+                <code>optgroup</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-optgroup-disabled">disabled</a></code>
+              </th>
+              <td>
+                <code>aria-disabled="true"</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>disabled</code> attribute on any element that is allowed the <code>disabled</code> attribute in HTML.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-disabled"><code>aria-disabled</code></a> attribute on any element that is allowed the <code>disabled</code> attribute in HTML, 
+                  or any element with a WAI-ARIA role which allows the <code>aria-disabled</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use <code>aria-disabled="true"</code> on any element which also has a <code>disabled</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use <code>aria-disabled="false"</code> on any element which also has a <code>disabled</code> attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-hidden" tabindex="-1">
+              <th>
+                Any element with a <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-hidden">hidden</a></code> attribute
+              </th>
+              <td>
+                <code>aria-hidden="true"</code>
+              </td>
+              <td>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-hidden"><code>aria-hidden</code></a> attribute on any HTML element that allows <a href="https://www.w3.org/TR/wai-aria-1.2/#global_states">global <code>aria-*</code> attributes</a> to 
+                  be specified, with the exception of focusable elements and the <a href="#el-body"><code>body</code></a> element.
+                </p>
+                <p>
+                  It is generally <em class="rfc2119">NOT RECOMMENDED</em> for authors to use <code>aria-hidden="true"</code> on any element which also has the <code>hidden</code> attribute specified. However, authors <em class="rfc2119">MUST NOT</em> use <code>aria-hidden="true"</code> on any element which also has the <code>hidden</code> attribute specified in the <code>until-found</code> state.
+                </p>
+                <div class="note" role="note" id="issue-container-generatedID-6"><div role="heading" class="note-title marker" id="h-note-8" aria-level="4"><span>Note</span></div><div class="">
+                  A focusable element is any element which can be focused by use of keyboard or pointer device. Focusable elements are not always elements which
+                  can be tabbed to via a keyboard. For instance, an element with <code>tabindex="-1"</code> is focusable but is not a tabbable element.
+                </div></div>
+                <div class="note" role="note" id="issue-container-generatedID-7"><div role="heading" class="note-title marker" id="h-note-9" aria-level="4"><span>Note</span></div><div class="">
+                  Using <code>aria-hidden="true"</code> on an element that has the <code>hidden</code> attribute is at best an unnecessary redundancy. At worst its usage can 
+                  prevent access to the content if the <code>hidden</code> attribute's default UA style of <code>display: none</code> has been purposeuflly overwritten by an author or user style sheet.
+                  Finally, if the <code>hidden</code> attribute has the value of <code>until-found</code>, the use of <code>aria-hidden=true</code> will prevent this content from being discoverable to users of assistive
+                  technology when it is found via a browser's in-page find feature and visually rendered to users.
+                </div></div>
+              </td>
+            </tr>
+            <tr id="att-placeholder" tabindex="-1">
+              <th>
+                Any element where the <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-placeholder">placeholder</a></code> attribute is allowed
+              </th>
+              <td>
+                <code>aria-placeholder="..."</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>placeholder</code> attribute on any element that is allowed the
+                  <code>placeholder</code> attribute in HTML.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-placeholder"><code>aria-placeholder</code></a> attribute on any element that is allowed the <code>placeholder</code> attribute in HTML, 
+                  or any element with a WAI-ARIA role which allows the <code>aria-placeholder</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use the <code>aria-placeholder</code> attribute on any element which also has a <code>placeholder</code> attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-max" tabindex="-1">
+              <th>
+                Any element where the <code>max</code> attribute is allowed: <code>meter</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-max">max</a></code>, <code>progress</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-progress-max">max</a></code>, and <code>input</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-max">max</a></code>
+              </th>
+              <td>
+                <code>aria-valuemax="..."</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>max</code> attribute on any element that is
+                  allowed the <code>max</code> attribute in HTML.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-valuemax"><code>aria-valuemax</code></a> attribute on any other element with a WAI-ARIA role which allows the <code>aria-valuemax</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use <code>aria-valuemax</code> on any element which allows the <code>max</code> attribute. Use the <code>max</code> attribute instead.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use <code>aria-valuemax</code> on any element which also has a <code>max</code> attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-min" tabindex="-1">
+              <th>
+                Any element where the <code>min</code> attribute is allowed: <code>meter</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-meter-min">min</a></code> and <code>input</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-min">min</a></code>
+              </th>
+              <td>
+                <code>aria-valuemin="..."</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>min</code> attribute on any element that is
+                  allowed the <code>min</code> attribute in HTML.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-valuemax"><code>aria-valuemin</code></a> attribute on any other element with a WAI-ARIA role which allows the <code>aria-valuemin</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use <code>aria-valuemin</code> on any element which allows the <code>min</code> attribute. Use the <code>min</code> attribute instead.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use <code>aria-valuemin</code> on any element which also has a <code>min</code> attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-readonly" tabindex="-1">
+              <th>
+                Any element which allows the <code>readonly</code> attribute:
+                <code>input</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-readonly">readonly</a></code>, <code>textarea</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-readonly">readonly</a></code> and <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/custom-elements.html#form-associated-custom-element">form-associated custom element</a> which allows <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/custom-elements.html#attr-face-readonly">readonly</a></code>
+              </th>
+              <td>
+                <code>aria-readonly="true"</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>readonly</code> attribute on any element that is
+                  allowed the <code>readonly</code> attribute in HTML.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-readonly"><code>aria-readonly</code></a> attribute on any element with a WAI-ARIA role which allows the attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-readonly="true"</code> on any element which also has a <code>readonly</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use <code>aria-readonly="false"</code> on any element which also has a <code>readonly</code> attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-contenteditable" tabindex="-1">
+              <th>
+                <p>
+                  Element with <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/interaction.html#attr-contenteditable">contenteditable</a></code><code>=true</code>
+                  or
+                  element without <code>contenteditable</code> attribute whose closest
+                  ancestor with a <code>contenteditable</code> attribute has
+                  <code>contenteditable="true"</code>.
+                </p>
+                <div class="note" role="note" id="issue-container-generatedID-8"><div role="heading" class="note-title marker" id="h-note-10" aria-level="4"><span>Note</span></div><p class="">
+                  This is equivalent to the <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-iscontenteditable"><code>isContentEditable</code></a>
+                  IDL attribute.
+                </p></div>
+              </th>
+              <td>
+                <code>aria-readonly="false"</code>
+              </td>
+              <td>
+                Authors <em class="rfc2119">MUST NOT</em> set <code>aria-readonly="true"</code> on an element that has <code>isContentEditable="true"</code>.
+              </td>
+            </tr>
+            <tr id="att-required" tabindex="-1">
+              <th>
+                Any element where the <code>required</code> attribute is allowed: <code>input</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/input.html#attr-input-required">required</a></code>, <code>textarea</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-textarea-required">required</a></code>, and <code>select</code> <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-required">required</a></code>
+              </th>
+              <td>
+                <code>aria-required="true"</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>required</code> attribute on any element
+                  that is allowed the <code>required</code> attribute in HTML.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MAY</em> use the <a href="https://www.w3.org/TR/wai-aria-1.2/#aria-required"><code>aria-required</code></a> attribute on any element that is allowed the <code>required</code> attribute in HTML, or any element with a WAI-ARIA role which allows the <code>aria-required</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-required="true"</code> on any element which also has a <code>required</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use <code>aria-required="false"</code> on any element which also has a <code>required</code> attribute.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-colspan" tabindex="-1">
+              <th>
+                Any element where the <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-colspan">colspan</a></code> attribute is allowed: <code>td</code> and <code>th</code>
+              </th>
+              <td>
+                <code>aria-colspan="..."</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>colspan</code> attribute on any element that is
+                  allowed the <code>colspan</code> attribute in HTML.
+                </p>
+                
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-colspan</code> attribute on any element which also has a <code>colspan</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use <code>aria-colspan</code> on any element which also has a <code>colspan</code> attribute, and the values of each attribute do not match.
+                </p>
+              </td>
+            </tr>
+            <tr id="att-rowspan" tabindex="-1">
+              <th>
+                Any element where the <code><a data-link-type="element-attr" href="https://html.spec.whatwg.org/multipage/tables.html#attr-tdth-rowspan">rowspan</a></code> attribute is allowed:
+                <code>td</code> and <code>th</code>
+              </th>
+              <td>
+                <code>aria-rowspan="..."</code>
+              </td>
+              <td>
+                <p>
+                  Use the <code>rowspan</code> attribute on any element that is
+                  allowed the <code>rowspan</code> attribute in HTML.
+                </p>
+                
+                <p>
+                  Authors <em class="rfc2119">SHOULD NOT</em> use the <code>aria-rowspan</code> attribute on any element which also has a <code>rowspan</code> attribute.
+                </p>
+                <p>
+                  Authors <em class="rfc2119">MUST NOT</em> use <code>aria-rowspan</code> on any element which also has a <code>rowspan</code> attribute, and the values of each attribute do not match.
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="addition" id="requirements-for-deprecated-aria-role-state-and-property-and-attributes"><div class="header-wrapper"><h3 id="docconformance-deprecated"><bdi class="secno">4.3 </bdi>
+          Requirements for deprecated ARIA role, state and property and attributes
+        </h3><a class="self-link" href="#docconformance-deprecated" aria-label="Permalink for Section 4.3"></a></div>
+        
+        <p>
+          The ARIA Specification's <a href="https://www.w3.org/TR/wai-aria-1.2/#deprecated">Deprecated Requirements</a> section indicates that if an ARIA feature is marked as deprecated then authors are advised not to use said feature for new content.
+        </p>
+        <p>
+          The following roles and attributes are deprecated features of ARIA and DPub ARIA. Conformance checkers <em class="rfc2119">MUST</em> warn authors about the deprecated status of these features. Whenever possible, authors are advised to use alternatives to deprecated features.
+        </p>
+
+        <section id="deprecated-aria-roles"><div class="header-wrapper"><h4 id="x4-3-1-deprecated-aria-roles"><bdi class="secno">4.3.1 </bdi>Deprecated ARIA roles</h4><a class="self-link" href="#deprecated-aria-roles" aria-label="Permalink for Section 4.3.1"></a></div>
+        <ul>  
+          <li><a href="https://www.w3.org/TR/wai-aria-1.2/#directory"><code>directory</code></a></li>
+        </ul>
+        <div class="note" role="note" id="issue-container-generatedID-9"><div role="heading" class="note-title marker" id="h-note-11" aria-level="4"><span>Note</span></div><div class="">
+          <p>The <code>directory</code> role is marked for deprecation in <cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">WAI-ARIA 1.2</a></cite>. In reality, the <code>directory</code> role had no functional difference to an element with an implicit or explicit <code>list</code> role. Authors are advised to use one of HTML's native list elements, or an ARIA <code>list</code> instead.</p>
+        </div></div>
+
+        </section><section id="deprecated-dpub-aria-roles"><div class="header-wrapper"><h4 id="x4-3-2-deprecated-dpub-aria-roles"><bdi class="secno">4.3.2 </bdi>Deprecated DPub ARIA roles</h4><a class="self-link" href="#deprecated-dpub-aria-roles" aria-label="Permalink for Section 4.3.2"></a></div>
+        <ul>
+          <li><a href="https://www.w3.org/TR/dpub-aria-1.1/#doc-biblioentry"><code>doc-biblioentry</code></a></li>
+          <li><a href="https://www.w3.org/TR/dpub-aria-1.1/#doc-endnote"><code>doc-endnote</code></a></li>
+        </ul>
+        <div class="note" role="note" id="issue-container-generatedID-10"><div role="heading" class="note-title marker" id="h-note-12" aria-level="4"><span>Note</span></div><div class="">
+          <p>The <code>doc-biblioentry</code> and <code>doc-endnote</code> roles are marked for deprecation in <cite><a data-matched-text="[[[dpub-aria-1.1]]]" href="https://www.w3.org/TR/dpub-aria-1.1/">Digital Publishing WAI-ARIA Module 1.1</a></cite>, as they are not valid children for an element with an implicit or explicit role of <code>list</code>. Authors can use standard list and child <code>li</code> elements without the need for these roles.</p>
+        </div></div>
+
+        </section><section id="deprecated-aria-attributes"><div class="header-wrapper"><h4 id="x4-3-3-deprecated-aria-attributes"><bdi class="secno">4.3.3 </bdi>Deprecated ARIA attributes</h4><a class="self-link" href="#deprecated-aria-attributes" aria-label="Permalink for Section 4.3.3"></a></div>
+        <ul>
+          <li><a href="https://www.w3.org/TR/wai-aria-1.1/#aria-dropeffect"><code>aria-dropeffect</code></a></li>
+          <li><a href="https://www.w3.org/TR/wai-aria-1.1/#aria-grabbed"><code>aria-grabbed</code></a></li>
+        </ul>
+        <div class="note" role="note" id="issue-container-generatedID-11"><div role="heading" class="note-title marker" id="h-note-13" aria-level="4"><span>Note</span></div><div class="">
+          <p>The <code>aria-dropeffect</code> and <code>aria-grabbed</code> attributes were deprecated in <cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.1" title="Accessible Rich Internet Applications (WAI-ARIA) 1.1">WAI-ARIA 1.1</a></cite>. There is presently no feature in ARIA to replace their proposed functionality.</p>
+        </div></div>
+      </section></section>
+      <section id="case-requirements-for-aria-role-state-and-property-attributes"><div class="header-wrapper"><h3 id="case-sensitivity"><bdi class="secno">4.4 </bdi>
+        Case requirements for ARIA role, state and property attributes
+      </h3><a class="self-link" href="#case-sensitivity" aria-label="Permalink for Section 4.4"></a></div>
+      
+      <p>
+        Authors <em class="rfc2119">SHOULD</em> use <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-lowercase">ASCII lowercase</a> for all <code>role</code> token values
+        and any state or property attributes (<code>aria-*</code>) whose values are
+        <a href="https://www.w3.org/TR/wai-aria-1.2/#propcharacteristic_value">defined as tokens</a>.
+      </p>
+
+      <div class="note" role="note" id="issue-container-generatedID-12"><div role="heading" class="note-title marker" id="h-note-14" aria-level="4"><span>Note</span></div><div class="">
+        <p>
+          While modern browsers treat the <code>role</code> or <code>aria-*</code> attribute values as <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive">ASCII case-insensitive</a>, not all assistive technologies will correctly parse these values.
+        </p>
+        <p>
+          To reduce interoperability issues, authors are strongly encouraged to use <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-lowercase">ASCII lowercase</a> for <code>aria-*</code> and <code>role</code> attribute values. Further, authors are encouraged to rigorously test with different browser and assistive technology combinations to ensure that their content will be correctly exposed to their users.
+        </p>
+      </div></div>
+      <aside class="example" id="example-16"><div class="marker">
+    <a class="self-link" href="#example-16">Example<bdi> 16</bdi></a>
+  </div>
+        <p>
+          <strong>Correct (conforming) examples:</strong>
+        </p>
+        <pre aria-busy="false"><code class="hljs xml"><span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"main"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">a</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"home/"</span> <span class="hljs-attr">aria-current</span>=<span class="hljs-string">"page"</span>&gt;</span>home<span class="hljs-tag">&lt;/<span class="hljs-name">a</span>&gt;</span></code></pre>
+        <p>
+          <strong>Incorrect (non-conforming) examples:</strong>
+        </p>
+        <pre aria-busy="false"><code class="hljs xml"><span class="hljs-comment">&lt;!-- DO NOT DO THE FOLLOWING --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"MAIN"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"Main"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">a</span> <span class="hljs-attr">href</span>=<span class="hljs-string">"home/"</span> <span class="hljs-attr">aria-current</span>=<span class="hljs-string">"Page"</span>&gt;</span>home<span class="hljs-tag">&lt;/<span class="hljs-name">a</span>&gt;</span></code></pre>
+      </aside>
+    </section>
+    </section>
+
+    <section class="informative" id="allowed-descendants-of-aria-roles"><div class="header-wrapper"><h2 id="x5-allowed-descendants-of-aria-roles"><bdi class="secno">5. </bdi>
+        Allowed descendants of ARIA roles
+      </h2><a class="self-link" href="#allowed-descendants-of-aria-roles" aria-label="Permalink for Section 5."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <p>The following table maps (and extends) the <a href="https://html.spec.whatwg.org/multipage/dom.html#kinds-of-content">Kinds of content</a> and allowed descendant
+        information (defined in the
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>] specification) to elements that have an equivalent <code>role</code>.</p>
+      <p>
+        Column 1 links to the normative <cite><a data-matched-text="[[[wai-aria-1.2]]]" href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> definitions for each ARIA <code>role</code>.
+        Column 2 identifies the <a href="https://html.spec.whatwg.org/multipage/dom.html#kinds-of-content">Kinds of content</a>
+        categories each <code>role</code> has when it is used on an HTML element.
+        Column 3 indicates what kinds of HTML elements can be descendants of
+        an element with an explicit <code>role</code> specified, often matching the HTML element with
+        the same <a href="#implicit">implicit</a> role.
+      </p>
+      <p>
+        For example, a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">button</a></code> element has an implicit <code>role=button</code>.
+        In HTML a <code>button</code> element allows <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">phrasing content</a> as descendants, and does not allow <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a>
+        or descendants with a <code>tabindex</code> attribute.  Therefore, any elements specified with a <code>role=button</code> would follow
+        the same descendant restrictions, and not allow any interactive content descendants,
+        elements with a <code>tabindex</code> specified, or any elements with role values
+        that are in the interactive content category (identified in column 3).
+      </p>
+      <div class="example" id="bad-descendants">
+        <strong>Examples of non-conforming descendants</strong>
+        <pre aria-busy="false"><code class="hljs xml"><span class="hljs-comment">&lt;!-- conformance checkers will report an error --&gt;</span>
+<span class="hljs-tag">&lt;<span class="hljs-name">button</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"button"</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"button"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">button</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">button</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+
+<span class="hljs-tag">&lt;<span class="hljs-name">div</span> <span class="hljs-attr">role</span>=<span class="hljs-string">"link"</span>&gt;</span>
+  <span class="hljs-tag">&lt;<span class="hljs-name">textarea</span>&gt;</span>...<span class="hljs-tag">&lt;/<span class="hljs-name">textarea</span>&gt;</span>
+<span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span></code></pre>
+      </div>
+
+    <p>
+      Additionally, there are certain roles which <cite><a data-matched-text="[[[wai-aria-1.2]]]" href="https://www.w3.org/TR/wai-aria-1.2/">Accessible Rich Internet Applications (WAI-ARIA) 1.2</a></cite> has specified specific requirements for their allowed descendants. These have been identified in column 3 (Descendant allowances) by indicating to "Refer to the 'Required Owned Elements'" for those particular roles.
+    </p>
+
+    <table id="aria-table" class="data">
+      <caption>
+        Allowed descendants of ARIA roles
+      </caption>
+      <thead>
+        <tr>
+          <th>
+            Role
+          </th>
+          <th>
+            Kind of content
+          </th>
+          <th>
+            Descendant allowances
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th tabindex="-1" id="index-aria-alert">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#alert"><code>alert</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-alertdialog">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#alertdialog"><code>alertdialog</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-application">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#application"><code>application</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-article">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#article"><code>article</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content-2">Sectioning content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-banner">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#banner"><code>banner</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a>, <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-header-element">header</a>, or <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-footer-element">footer</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-blockquote">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#blockquote"><code>blockquote</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-button">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#button"><code>button</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-caption">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#caption"><code>caption</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> or <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/tables.html#the-table-element">table</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-cell">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#cell"><code>cell</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-checkbox">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#checkbox"><code>checkbox</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-code">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#code"><code>code</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-columnheader">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#columnheader"><code>columnheader</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a>, <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-header-element">header</a>, or <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-footer-element">footer</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-combobox">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#combobox"><code>combobox</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-complementary">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#complementary"><code>complementary</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content-2">Sectioning content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-contentinfo">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#contentinfo"><code>contentinfo</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a>, <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-header-element">header</a>, or <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/sections.html#the-footer-element">footer</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-definition">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#definition"><code>definition</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-deletion">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#deletion"><code>deletion</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-dialog">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#dialog"><code>dialog</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-directory">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#directory"><code>directory</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-document">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#document"><code>document</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-emphasis">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#emphasis"><code>emphasis</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-feed">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#feed"><code>feed</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-figure">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#figure"><code>figure</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-form">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#form"><code>form</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/forms.html#the-form-element">form</a></code> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-generic">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#generic"><code>generic</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-grid">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#grid"><code>grid</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#grid"><code>grid</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-gridcell">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#gridcell"><code>gridcell</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-group">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#group"><code>group</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-heading">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#heading"><code>heading</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#heading-content-2">Heading content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-img">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#img"><code>img</code> or <code>image</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#embedded-content-category">Embedded content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-insertion">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#insertion"><code>insertion</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-link">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#link"><code>link</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-list">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#list"><code>list</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#list"><code>list</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-listbox">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#listbox"><code>listbox</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#listbox"><code>listbox</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-listitem">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#listitem"><code>listitem</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-log">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#log"><code>log</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-main">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#main"><code>main</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-marquee">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#marquee"><code>marquee</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-math">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#math"><code>math</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-menu">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#menu"><code>menu</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#menu"><code>menu</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-menubar">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#menubar"><code>menubar</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#menubar"><code>menubar</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-menuitem">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#menuitem"><code>menuitem</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-menuitemcheckbox">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#menuitemcheckbox"><code>menuitemcheckbox</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-menuitemradio">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#menuitemradio"><code>menuitemradio</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-meter">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#meter"><code>meter</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-meter-element">meter</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-navigation">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#navigation"><code>navigation</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content-2">Sectioning content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-none">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#none"><code>none</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            <a href="https://html.spec.whatwg.org/multipage/dom.html#transparent-content-models">Transparent</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-note">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#note"><code>note</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-option">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#option"><code>option</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-paragraph">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#paragraph"><code>paragraph</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-presentation">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#presentation"><code>presentation</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            <a href="https://html.spec.whatwg.org/multipage/dom.html#transparent-content-models">Transparent</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-progressbar">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#progressbar"><code>progressbar</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-progress-element">progress</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-radio">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#radio"><code>radio</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-radiogroup">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#radiogroup"><code>radiogroup</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-region">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#region"><code>region</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#sectioning-content-2">Sectioning content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>, but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-row">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#row"><code>row</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#row"><code>row</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-rowgroup">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#rowgroup"><code>rowgroup</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#rowgroup"><code>rowgroup</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-rowheader">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#rowheader"><code>rowheader</code></a>
+          </th>
+          <td>
+            N/A
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-scrollbar">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#scrollbar"><code>scrollbar</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-search">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#search"><code>search</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-searchbox">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#searchbox"><code>searchbox</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-separator">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#separator"><code>separator</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a> (if focusable)
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-slider">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#slider"><code>slider</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-spinbutton">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#spinbutton"><code>spinbutton</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-status">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#status"><code>status</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-strong">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#strong"><code>strong</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-subscript">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#subscript"><code>subscript</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-superscript">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#superscript"><code>superscript</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-switch">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#switch"><code>switch</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-tab">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#tab"><code>tab</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>, but with no
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">interactive content</a> descendants, and no descendants with a <code>tabindex</code> attribute specified.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-table">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#table"><code>table</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#table"><code>table</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-tablist">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#tablist"><code>tablist</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <a href="https://www.w3.org/TR/wai-aria-1.2/#tablist"><code>tablist</code></a> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-tabpanel">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#tabpanel"><code>tabpanel</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+        </tr>
+        <tr>
+          <th id="index-aria-term" tabindex="-1">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#term"><code>term</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-textbox">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#textbox"><code>textbox</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-time">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#time"><code>time</code></a>
+          </th>
+          <td>
+            <ul>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a></li>
+              <li><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#palpable-content-2">Palpable content</a></li>
+            </ul>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-timer">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#timer"><code>timer</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-toolbar">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#toolbar"><code>toolbar</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a> but with no <a data-link-type="element" href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-main-element">main</a> element descendants.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-tooltip">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#tooltip"><code>tooltip</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-tree">
+           <a href="https://www.w3.org/TR/wai-aria-1.2/#tree"><code>tree</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <code><a href="https://www.w3.org/TR/wai-aria-1.2/#tree">tree</a></code> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-treegrid">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#treegrid"><code>treegrid</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#flow-content-2">Flow content</a>
+          </td>
+          <td>
+            Refer to the "Required Owned Elements" as defined for the ARIA <code><a href="https://www.w3.org/TR/wai-aria-1.2/#treegrid">treegrid</a></code> role.
+          </td>
+        </tr>
+        <tr>
+          <th tabindex="-1" id="index-aria-treeitem">
+            <a href="https://www.w3.org/TR/wai-aria-1.2/#treeitem"><code>treeitem</code></a>
+          </th>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#interactive-content-2">Interactive content</a>
+          </td>
+          <td>
+            <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#phrasing-content-2">Phrasing content</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    </section>
+    <section id="conformance"><div class="header-wrapper"><h2 id="x6-conformance"><bdi class="secno">6. </bdi>Conformance</h2><a class="self-link" href="#conformance" aria-label="Permalink for Section 6."></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+        The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">NOT RECOMMENDED</em>, <em class="rfc2119">SHOULD</em>, and <em class="rfc2119">SHOULD NOT</em> in this document
+        are to be interpreted as described in
+        <a href="https://www.rfc-editor.org/info/bcp14">BCP 14</a>
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+        when, and only when, they appear in all
+        capitals, as shown here.
+      </p>
+      <section id="conformance-checking-requirements"><div class="header-wrapper"><h3 id="x6-1-conformance-checking-requirements"><bdi class="secno">6.1 </bdi>Conformance checking requirements</h3><a class="self-link" href="#conformance-checking-requirements" aria-label="Permalink for Section 6.1"></a></div>
+      <p>Conformance checkers that claim support for checking ARIA in HTML documents
+        <em class="rfc2119">MUST</em> implement checks for the conformance requirements for use of the ARIA <code>role</code>
+        and <code>aria-*</code> attributes on <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">HTML elements</a> as defined in this specification. </p>
+      <p>
+        A conforming document <em class="rfc2119">MUST NOT</em> contain any elements with author defined <code>role</code>
+        or <code>aria-*</code> attributes with values other than those which, per this specification,
+        authors <em class="rfc2119">MAY</em> use on each <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#html-elements">HTML element</a> in <a href="#docconformance" data-matched-text="[[[#docconformance]]]" class="sec-ref"><bdi class="secno">4. </bdi>
+        Document conformance requirements for use of ARIA attributes in HTML</a>.
+        Conformance checkers <em class="rfc2119">SHOULD</em> flag instances where authors are explicitly providing
+        an element with a <code>role</code> which matches its
+        <a href="https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics">implicit ARIA semantics</a> as failures,
+        as it is <em class="rfc2119">NOT RECOMMENDED</em> for authors to explicitly set these roles.
+      </p>
+      <p>
+        A conformance checker <em class="rfc2119">MAY</em> define their own terminology, and level or levels of
+        severity, when surfacing document failures to conform to this specification.
+      </p>
+    </section></section>
+    <section id="priv-sec" class="informative"><div class="header-wrapper"><h2 id="x7-privacy-and-security-considerations"><bdi class="secno">7. </bdi>
+        Privacy and security considerations
+      </h2><a class="self-link" href="#priv-sec" aria-label="Permalink for Section 7."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <p>
+        This specification does not define the features of [<cite><a class="bibref" data-link-type="biblio" href="#bib-wai-aria-1.2" title="Accessible Rich Internet Applications (WAI-ARIA) 1.2">wai-aria-1.2</a></cite>],
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-dpub-aria-1.0" title="Digital Publishing WAI-ARIA Module 1.0">dpub-aria-1.0</a></cite>] or [<cite><a class="bibref" data-link-type="biblio" href="#bib-html" title="HTML Standard">HTML</a></cite>]. Rather it provides rules and guidance for conformance
+        checkers that claim support for checking ARIA in HTML, as well as providing guidance to authors.
+      </p>
+      <p>
+        Therefore, there are no known privacy or security impacts of this specification,
+        as it defines no new features to introduce potential concern.
+      </p>
+    </section>
+  
+
+<section id="references" class="appendix"><div class="header-wrapper"><h2 id="a-references"><bdi class="secno">A. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix A."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="a-1-normative-references"><bdi class="secno">A.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix A.1"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-accname-1.2">[accname-1.2]</dt><dd>
+      <a href="https://www.w3.org/TR/accname-1.2/"><cite>Accessible Name and Description Computation 1.2</cite></a>. Bryan Garaventa; Melanie Sumner.  W3C. 17 June 2025. W3C Working Draft. URL: <a href="https://www.w3.org/TR/accname-1.2/">https://www.w3.org/TR/accname-1.2/</a>
+    </dd><dt id="bib-dpub-aria-1.0">[dpub-aria-1.0]</dt><dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.0/"><cite>Digital Publishing WAI-ARIA Module 1.0</cite></a>. Matt Garrish; Tzviya Siegman; Markus Gylling; Shane McCarron.  W3C. 14 December 2017. W3C Recommendation. URL: <a href="https://www.w3.org/TR/dpub-aria-1.0/">https://www.w3.org/TR/dpub-aria-1.0/</a>
+    </dd><dt id="bib-dpub-aria-1.1">[dpub-aria-1.1]</dt><dd>
+      <a href="https://www.w3.org/TR/dpub-aria-1.1/"><cite>Digital Publishing WAI-ARIA Module 1.1</cite></a>. Matt Garrish; Tzviya Siegman.  W3C. 12 June 2025. W3C Recommendation. URL: <a href="https://www.w3.org/TR/dpub-aria-1.1/">https://www.w3.org/TR/dpub-aria-1.1/</a>
+    </dd><dt id="bib-html">[html]</dt><dd>
+      <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Anne van Kesteren; Domenic Denicola; Dominic Farolino; Ian Hickson; Philip Jägenstedt; Simon Pieters.  WHATWG. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+    </dd><dt id="bib-html-aam-1.0">[html-aam-1.0]</dt><dd>
+      <a href="https://www.w3.org/TR/html-aam-1.0/"><cite>HTML Accessibility API Mappings 1.0</cite></a>. Scott O'Hara; Rahim Abdi.  W3C. 30 July 2025. W3C Working Draft. URL: <a href="https://www.w3.org/TR/html-aam-1.0/">https://www.w3.org/TR/html-aam-1.0/</a>
+    </dd><dt id="bib-infra">[infra]</dt><dd>
+      <a href="https://infra.spec.whatwg.org/"><cite>Infra Standard</cite></a>. Anne van Kesteren; Domenic Denicola.  WHATWG. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
+    </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+    </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+    </dd><dt id="bib-svg-aam-1.0">[svg-aam-1.0]</dt><dd>
+      <a href="https://www.w3.org/TR/svg-aam-1.0/"><cite>SVG Accessibility API Mappings</cite></a>. Amelia Bellamy-Royds; Ian Pouncey.  W3C. 10 May 2018. W3C Working Draft. URL: <a href="https://www.w3.org/TR/svg-aam-1.0/">https://www.w3.org/TR/svg-aam-1.0/</a>
+    </dd><dt id="bib-wai-aria-1.1">[wai-aria-1.1]</dt><dd>
+      <a href="https://www.w3.org/TR/wai-aria-1.1/"><cite>Accessible Rich Internet Applications (WAI-ARIA) 1.1</cite></a>. Joanmarie Diggs; Shane McCarron; Michael Cooper; Richard Schwerdtfeger; James Craig.  W3C. 14 December 2017. W3C Recommendation. URL: <a href="https://www.w3.org/TR/wai-aria-1.1/">https://www.w3.org/TR/wai-aria-1.1/</a>
+    </dd><dt id="bib-wai-aria-1.2">[wai-aria-1.2]</dt><dd>
+      <a href="https://www.w3.org/TR/wai-aria-1.2/"><cite>Accessible Rich Internet Applications (WAI-ARIA) 1.2</cite></a>. Joanmarie Diggs; James Nurthen; Michael Cooper; Carolyn MacLeod.  W3C. 6 June 2023. W3C Recommendation. URL: <a href="https://www.w3.org/TR/wai-aria-1.2/">https://www.w3.org/TR/wai-aria-1.2/</a>
+    </dd></dl>
+  </section><section id="informative-references"><div class="header-wrapper"><h3 id="a-2-informative-references"><bdi class="secno">A.2 </bdi>Informative references</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix A.2"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-using-aria">[using-aria]</dt><dd>
+      <a href="https://www.w3.org/TR/using-aria/"><cite>Using ARIA</cite></a>. Steve Faulkner; David MacDonald.  W3C. 27 September 2018. W3C Working Draft. URL: <a href="https://www.w3.org/TR/using-aria/">https://www.w3.org/TR/using-aria/</a>
+    </dd><dt id="bib-wai-aria-practices-1.2">[wai-aria-practices-1.2]</dt><dd>
+      <a href="https://www.w3.org/TR/wai-aria-practices-1.2/"><cite>WAI-ARIA Authoring Practices 1.2</cite></a>. Matthew King; JaEun Jemma Ku; James Nurthen; Zoë Bijl; Michael Cooper.  W3C. 19 May 2022. W3C Working Group Note. URL: <a href="https://www.w3.org/TR/wai-aria-practices-1.2/">https://www.w3.org/TR/wai-aria-practices-1.2/</a>
+    </dd></dl>
+  </section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-any-role" aria-label="Links in this document to definition: Any role">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-any-role" aria-label="Permalink for definition: Any role. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-any-role-1" title="§ 4. Document conformance requirements for use of ARIA attributes in HTML">§ 4. Document conformance requirements for use of ARIA attributes in HTML</a> <a href="#ref-for-dfn-any-role-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-any-role-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-any-role-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-any-role-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-any-role-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-any-role-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-any-role-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-any-role-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-any-role-10" title="Reference 10">(10)</a> <a href="#ref-for-dfn-any-role-11" title="Reference 11">(11)</a> <a href="#ref-for-dfn-any-role-12" title="Reference 12">(12)</a> <a href="#ref-for-dfn-any-role-13" title="Reference 13">(13)</a> <a href="#ref-for-dfn-any-role-14" title="Reference 14">(14)</a> <a href="#ref-for-dfn-any-role-15" title="Reference 15">(15)</a> <a href="#ref-for-dfn-any-role-16" title="Reference 16">(16)</a> <a href="#ref-for-dfn-any-role-17" title="Reference 17">(17)</a> <a href="#ref-for-dfn-any-role-18" title="Reference 18">(18)</a> <a href="#ref-for-dfn-any-role-19" title="Reference 19">(19)</a> <a href="#ref-for-dfn-any-role-20" title="Reference 20">(20)</a> <a href="#ref-for-dfn-any-role-21" title="Reference 21">(21)</a> <a href="#ref-for-dfn-any-role-22" title="Reference 22">(22)</a> <a href="#ref-for-dfn-any-role-23" title="Reference 23">(23)</a> <a href="#ref-for-dfn-any-role-24" title="Reference 24">(24)</a> <a href="#ref-for-dfn-any-role-25" title="Reference 25">(25)</a> <a href="#ref-for-dfn-any-role-26" title="Reference 26">(26)</a> <a href="#ref-for-dfn-any-role-27" title="Reference 27">(27)</a> <a href="#ref-for-dfn-any-role-28" title="Reference 28">(28)</a> <a href="#ref-for-dfn-any-role-29" title="Reference 29">(29)</a> <a href="#ref-for-dfn-any-role-30" title="Reference 30">(30)</a> <a href="#ref-for-dfn-any-role-31" title="Reference 31">(31)</a> <a href="#ref-for-dfn-any-role-32" title="Reference 32">(32)</a> <a href="#ref-for-dfn-any-role-33" title="Reference 33">(33)</a> <a href="#ref-for-dfn-any-role-34" title="Reference 34">(34)</a> <a href="#ref-for-dfn-any-role-35" title="Reference 35">(35)</a> <a href="#ref-for-dfn-any-role-36" title="Reference 36">(36)</a> <a href="#ref-for-dfn-any-role-37" title="Reference 37">(37)</a> <a href="#ref-for-dfn-any-role-38" title="Reference 38">(38)</a> <a href="#ref-for-dfn-any-role-39" title="Reference 39">(39)</a> <a href="#ref-for-dfn-any-role-40" title="Reference 40">(40)</a> <a href="#ref-for-dfn-any-role-41" title="Reference 41">(41)</a> <a href="#ref-for-dfn-any-role-42" title="Reference 42">(42)</a> <a href="#ref-for-dfn-any-role-43" title="Reference 43">(43)</a> <a href="#ref-for-dfn-any-role-44" title="Reference 44">(44)</a> <a href="#ref-for-dfn-any-role-45" title="Reference 45">(45)</a> <a href="#ref-for-dfn-any-role-46" title="Reference 46">(46)</a> <a href="#ref-for-dfn-any-role-47" title="Reference 47">(47)</a> <a href="#ref-for-dfn-any-role-48" title="Reference 48">(48)</a> <a href="#ref-for-dfn-any-role-49" title="Reference 49">(49)</a> <a href="#ref-for-dfn-any-role-50" title="Reference 50">(50)</a> <a href="#ref-for-dfn-any-role-51" title="Reference 51">(51)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-no-role" aria-label="Links in this document to definition: No role">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-no-role" aria-label="Permalink for definition: No role. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-no-role-1" title="§ 4. Document conformance requirements for use of ARIA attributes in HTML">§ 4. Document conformance requirements for use of ARIA attributes in HTML</a> <a href="#ref-for-dfn-no-role-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-no-role-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-no-role-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-no-role-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-no-role-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-no-role-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-no-role-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-no-role-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-no-role-10" title="Reference 10">(10)</a> <a href="#ref-for-dfn-no-role-11" title="Reference 11">(11)</a> <a href="#ref-for-dfn-no-role-12" title="Reference 12">(12)</a> <a href="#ref-for-dfn-no-role-13" title="Reference 13">(13)</a> <a href="#ref-for-dfn-no-role-14" title="Reference 14">(14)</a> <a href="#ref-for-dfn-no-role-15" title="Reference 15">(15)</a> <a href="#ref-for-dfn-no-role-16" title="Reference 16">(16)</a> <a href="#ref-for-dfn-no-role-17" title="Reference 17">(17)</a> <a href="#ref-for-dfn-no-role-18" title="Reference 18">(18)</a> <a href="#ref-for-dfn-no-role-19" title="Reference 19">(19)</a> <a href="#ref-for-dfn-no-role-20" title="Reference 20">(20)</a> <a href="#ref-for-dfn-no-role-21" title="Reference 21">(21)</a> <a href="#ref-for-dfn-no-role-22" title="Reference 22">(22)</a> <a href="#ref-for-dfn-no-role-23" title="Reference 23">(23)</a> <a href="#ref-for-dfn-no-role-24" title="Reference 24">(24)</a> <a href="#ref-for-dfn-no-role-25" title="Reference 25">(25)</a> <a href="#ref-for-dfn-no-role-26" title="Reference 26">(26)</a> <a href="#ref-for-dfn-no-role-27" title="Reference 27">(27)</a> <a href="#ref-for-dfn-no-role-28" title="Reference 28">(28)</a> <a href="#ref-for-dfn-no-role-29" title="Reference 29">(29)</a> <a href="#ref-for-dfn-no-role-30" title="Reference 30">(30)</a> <a href="#ref-for-dfn-no-role-31" title="Reference 31">(31)</a> <a href="#ref-for-dfn-no-role-32" title="Reference 32">(32)</a> <a href="#ref-for-dfn-no-role-33" title="Reference 33">(33)</a> <a href="#ref-for-dfn-no-role-34" title="Reference 34">(34)</a> <a href="#ref-for-dfn-no-role-35" title="Reference 35">(35)</a> <a href="#ref-for-dfn-no-role-36" title="Reference 36">(36)</a> <a href="#ref-for-dfn-no-role-37" title="Reference 37">(37)</a> <a href="#ref-for-dfn-no-role-38" title="Reference 38">(38)</a> <a href="#ref-for-dfn-no-role-39" title="Reference 39">(39)</a> <a href="#ref-for-dfn-no-role-40" title="Reference 40">(40)</a> <a href="#ref-for-dfn-no-role-41" title="Reference 41">(41)</a> <a href="#ref-for-dfn-no-role-42" title="Reference 42">(42)</a> <a href="#ref-for-dfn-no-role-43" title="Reference 43">(43)</a> <a href="#ref-for-dfn-no-role-44" title="Reference 44">(44)</a> <a href="#ref-for-dfn-no-role-45" title="Reference 45">(45)</a> <a href="#ref-for-dfn-no-role-46" title="Reference 46">(46)</a> <a href="#ref-for-dfn-no-role-47" title="Reference 47">(47)</a> <a href="#ref-for-dfn-no-role-48" title="Reference 48">(48)</a> <a href="#ref-for-dfn-no-role-49" title="Reference 49">(49)</a> <a href="#ref-for-dfn-no-role-50" title="Reference 50">(50)</a> <a href="#ref-for-dfn-no-role-51" title="Reference 51">(51)</a> <a href="#ref-for-dfn-no-role-52" title="Reference 52">(52)</a> <a href="#ref-for-dfn-no-role-53" title="Reference 53">(53)</a> <a href="#ref-for-dfn-no-role-54" title="Reference 54">(54)</a> <a href="#ref-for-dfn-no-role-55" title="Reference 55">(55)</a> <a href="#ref-for-dfn-no-role-56" title="Reference 56">(56)</a> <a href="#ref-for-dfn-no-role-57" title="Reference 57">(57)</a> <a href="#ref-for-dfn-no-role-58" title="Reference 58">(58)</a> <a href="#ref-for-dfn-no-role-59" title="Reference 59">(59)</a> <a href="#ref-for-dfn-no-role-60" title="Reference 60">(60)</a> <a href="#ref-for-dfn-no-role-61" title="Reference 61">(61)</a> <a href="#ref-for-dfn-no-role-62" title="Reference 62">(62)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-naming-prohibited" aria-label="Links in this document to definition: Naming prohibited">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-naming-prohibited" aria-label="Permalink for definition: Naming prohibited. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-naming-prohibited-1" title="§ Status of This Document">§ Status of This Document</a> 
+    </li><li>
+      <a href="#ref-for-dfn-naming-prohibited-2" title="§ 4. Document conformance requirements for use of ARIA attributes in HTML">§ 4. Document conformance requirements for use of ARIA attributes in HTML</a> <a href="#ref-for-dfn-naming-prohibited-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-naming-prohibited-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-naming-prohibited-5" title="Reference 4">(4)</a> <a href="#ref-for-dfn-naming-prohibited-6" title="Reference 5">(5)</a> <a href="#ref-for-dfn-naming-prohibited-7" title="Reference 6">(6)</a> <a href="#ref-for-dfn-naming-prohibited-8" title="Reference 7">(7)</a> <a href="#ref-for-dfn-naming-prohibited-9" title="Reference 8">(8)</a> <a href="#ref-for-dfn-naming-prohibited-10" title="Reference 9">(9)</a> <a href="#ref-for-dfn-naming-prohibited-11" title="Reference 10">(10)</a> <a href="#ref-for-dfn-naming-prohibited-12" title="Reference 11">(11)</a> <a href="#ref-for-dfn-naming-prohibited-13" title="Reference 12">(12)</a> <a href="#ref-for-dfn-naming-prohibited-14" title="Reference 13">(13)</a> <a href="#ref-for-dfn-naming-prohibited-15" title="Reference 14">(14)</a> <a href="#ref-for-dfn-naming-prohibited-16" title="Reference 15">(15)</a> <a href="#ref-for-dfn-naming-prohibited-17" title="Reference 16">(16)</a> <a href="#ref-for-dfn-naming-prohibited-18" title="Reference 17">(17)</a> <a href="#ref-for-dfn-naming-prohibited-19" title="Reference 18">(18)</a> <a href="#ref-for-dfn-naming-prohibited-20" title="Reference 19">(19)</a> <a href="#ref-for-dfn-naming-prohibited-21" title="Reference 20">(20)</a> <a href="#ref-for-dfn-naming-prohibited-22" title="Reference 21">(21)</a> <a href="#ref-for-dfn-naming-prohibited-23" title="Reference 22">(22)</a> <a href="#ref-for-dfn-naming-prohibited-24" title="Reference 23">(23)</a> <a href="#ref-for-dfn-naming-prohibited-25" title="Reference 24">(24)</a> <a href="#ref-for-dfn-naming-prohibited-26" title="Reference 25">(25)</a> <a href="#ref-for-dfn-naming-prohibited-27" title="Reference 26">(26)</a> <a href="#ref-for-dfn-naming-prohibited-28" title="Reference 27">(27)</a> <a href="#ref-for-dfn-naming-prohibited-29" title="Reference 28">(28)</a> <a href="#ref-for-dfn-naming-prohibited-30" title="Reference 29">(29)</a> <a href="#ref-for-dfn-naming-prohibited-31" title="Reference 30">(30)</a> <a href="#ref-for-dfn-naming-prohibited-32" title="Reference 31">(31)</a> <a href="#ref-for-dfn-naming-prohibited-33" title="Reference 32">(32)</a> <a href="#ref-for-dfn-naming-prohibited-34" title="Reference 33">(33)</a> <a href="#ref-for-dfn-naming-prohibited-35" title="Reference 34">(34)</a> <a href="#ref-for-dfn-naming-prohibited-36" title="Reference 35">(35)</a> <a href="#ref-for-dfn-naming-prohibited-37" title="Reference 36">(36)</a> <a href="#ref-for-dfn-naming-prohibited-38" title="Reference 37">(37)</a> <a href="#ref-for-dfn-naming-prohibited-39" title="Reference 38">(38)</a> <a href="#ref-for-dfn-naming-prohibited-40" title="Reference 39">(39)</a> <a href="#ref-for-dfn-naming-prohibited-41" title="Reference 40">(40)</a> <a href="#ref-for-dfn-naming-prohibited-42" title="Reference 41">(41)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-no-corresponding-role" aria-label="Links in this document to definition: No corresponding role">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-no-corresponding-role" aria-label="Permalink for definition: No corresponding role. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-no-corresponding-role-1" title="§ 4. Document conformance requirements for use of ARIA attributes in HTML">§ 4. Document conformance requirements for use of ARIA attributes in HTML</a> <a href="#ref-for-dfn-no-corresponding-role-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-no-corresponding-role-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-no-corresponding-role-4" title="Reference 4">(4)</a> <a href="#ref-for-dfn-no-corresponding-role-5" title="Reference 5">(5)</a> <a href="#ref-for-dfn-no-corresponding-role-6" title="Reference 6">(6)</a> <a href="#ref-for-dfn-no-corresponding-role-7" title="Reference 7">(7)</a> <a href="#ref-for-dfn-no-corresponding-role-8" title="Reference 8">(8)</a> <a href="#ref-for-dfn-no-corresponding-role-9" title="Reference 9">(9)</a> <a href="#ref-for-dfn-no-corresponding-role-10" title="Reference 10">(10)</a> <a href="#ref-for-dfn-no-corresponding-role-11" title="Reference 11">(11)</a> <a href="#ref-for-dfn-no-corresponding-role-12" title="Reference 12">(12)</a> <a href="#ref-for-dfn-no-corresponding-role-13" title="Reference 13">(13)</a> <a href="#ref-for-dfn-no-corresponding-role-14" title="Reference 14">(14)</a> <a href="#ref-for-dfn-no-corresponding-role-15" title="Reference 15">(15)</a> <a href="#ref-for-dfn-no-corresponding-role-16" title="Reference 16">(16)</a> <a href="#ref-for-dfn-no-corresponding-role-17" title="Reference 17">(17)</a> <a href="#ref-for-dfn-no-corresponding-role-18" title="Reference 18">(18)</a> <a href="#ref-for-dfn-no-corresponding-role-19" title="Reference 19">(19)</a> <a href="#ref-for-dfn-no-corresponding-role-20" title="Reference 20">(20)</a> <a href="#ref-for-dfn-no-corresponding-role-21" title="Reference 21">(21)</a> <a href="#ref-for-dfn-no-corresponding-role-22" title="Reference 22">(22)</a> <a href="#ref-for-dfn-no-corresponding-role-23" title="Reference 23">(23)</a> <a href="#ref-for-dfn-no-corresponding-role-24" title="Reference 24">(24)</a> <a href="#ref-for-dfn-no-corresponding-role-25" title="Reference 25">(25)</a> <a href="#ref-for-dfn-no-corresponding-role-26" title="Reference 26">(26)</a> <a href="#ref-for-dfn-no-corresponding-role-27" title="Reference 27">(27)</a> <a href="#ref-for-dfn-no-corresponding-role-28" title="Reference 28">(28)</a> <a href="#ref-for-dfn-no-corresponding-role-29" title="Reference 29">(29)</a> <a href="#ref-for-dfn-no-corresponding-role-30" title="Reference 30">(30)</a> <a href="#ref-for-dfn-no-corresponding-role-31" title="Reference 31">(31)</a> <a href="#ref-for-dfn-no-corresponding-role-32" title="Reference 32">(32)</a> <a href="#ref-for-dfn-no-corresponding-role-33" title="Reference 33">(33)</a> <a href="#ref-for-dfn-no-corresponding-role-34" title="Reference 34">(34)</a> <a href="#ref-for-dfn-no-corresponding-role-35" title="Reference 35">(35)</a> <a href="#ref-for-dfn-no-corresponding-role-36" title="Reference 36">(36)</a> <a href="#ref-for-dfn-no-corresponding-role-37" title="Reference 37">(37)</a> <a href="#ref-for-dfn-no-corresponding-role-38" title="Reference 38">(38)</a> <a href="#ref-for-dfn-no-corresponding-role-39" title="Reference 39">(39)</a> <a href="#ref-for-dfn-no-corresponding-role-40" title="Reference 40">(40)</a> <a href="#ref-for-dfn-no-corresponding-role-41" title="Reference 41">(41)</a> <a href="#ref-for-dfn-no-corresponding-role-42" title="Reference 42">(42)</a> <a href="#ref-for-dfn-no-corresponding-role-43" title="Reference 43">(43)</a> <a href="#ref-for-dfn-no-corresponding-role-44" title="Reference 44">(44)</a> <a href="#ref-for-dfn-no-corresponding-role-45" title="Reference 45">(45)</a> <a href="#ref-for-dfn-no-corresponding-role-46" title="Reference 46">(46)</a> <a href="#ref-for-dfn-no-corresponding-role-47" title="Reference 47">(47)</a> <a href="#ref-for-dfn-no-corresponding-role-48" title="Reference 48">(48)</a> <a href="#ref-for-dfn-no-corresponding-role-49" title="Reference 49">(49)</a> <a href="#ref-for-dfn-no-corresponding-role-50" title="Reference 50">(50)</a> <a href="#ref-for-dfn-no-corresponding-role-51" title="Reference 51">(51)</a> 
+    </li>
+  </ul>
+    </div><script id="respec-highlight-vars">(() => {
+// @ts-check
+
+if (document.respec) {
+  document.respec.ready.then(setupVarHighlighter);
+} else {
+  setupVarHighlighter();
+}
+
+function setupVarHighlighter() {
+  document
+    .querySelectorAll("var")
+    .forEach(varElem => varElem.addEventListener("click", highlightListener));
+}
+
+function highlightListener(ev) {
+  ev.stopPropagation();
+  const { target: varElem } = ev;
+  const hightligtedElems = highlightVars(varElem);
+  const resetListener = () => {
+    const hlColor = getHighlightColor(varElem);
+    hightligtedElems.forEach(el => removeHighlight(el, hlColor));
+    [...HL_COLORS.keys()].forEach(key => HL_COLORS.set(key, true));
+  };
+  if (hightligtedElems.length) {
+    document.body.addEventListener("click", resetListener, { once: true });
+  }
+}
+
+// availability of highlight colors. colors from var.css
+const HL_COLORS = new Map([
+  ["respec-hl-c1", true],
+  ["respec-hl-c2", true],
+  ["respec-hl-c3", true],
+  ["respec-hl-c4", true],
+  ["respec-hl-c5", true],
+  ["respec-hl-c6", true],
+  ["respec-hl-c7", true],
+]);
+
+function getHighlightColor(target) {
+  // return current colors if applicable
+  const { value } = target.classList;
+  const re = /respec-hl-\w+/;
+  const activeClass = re.test(value) && value.match(re);
+  if (activeClass) return activeClass[0];
+
+  // first color preference
+  if (HL_COLORS.get("respec-hl-c1") === true) return "respec-hl-c1";
+
+  // otherwise get some other available color
+  return [...HL_COLORS.keys()].find(c => HL_COLORS.get(c)) || "respec-hl-c1";
+}
+
+function highlightVars(varElem) {
+  const textContent = norm(varElem.textContent);
+  const parent = varElem.closest(".algorithm, section");
+  const highlightColor = getHighlightColor(varElem);
+
+  const varsToHighlight = [...parent.querySelectorAll("var")].filter(
+    el =>
+      norm(el.textContent) === textContent &&
+      el.closest(".algorithm, section") === parent
+  );
+
+  // update availability of highlight color
+  const colorStatus = varsToHighlight[0].classList.contains("respec-hl");
+  HL_COLORS.set(highlightColor, colorStatus);
+
+  // highlight vars
+  if (colorStatus) {
+    varsToHighlight.forEach(el => removeHighlight(el, highlightColor));
+    return [];
+  } else {
+    varsToHighlight.forEach(el => addHighlight(el, highlightColor));
+  }
+  return varsToHighlight;
+}
+
+function removeHighlight(el, highlightColor) {
+  el.classList.remove("respec-hl", highlightColor);
+  // clean up empty class attributes so they don't come in export
+  if (!el.classList.length) el.removeAttribute("class");
+}
+
+function addHighlight(elem, highlightColor) {
+  elem.classList.add("respec-hl", highlightColor);
+}
+
+/**
+ * Same as `norm` from src/core/utils, but our build process doesn't allow
+ * imports in runtime scripts, so duplicated here.
+ * @param {string} str
+ */
+function norm(str) {
+  return str.trim().replace(/\s+/g, " ");
+}
+})()</script><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
+
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>


### PR DESCRIPTION
## Summary
- add the current W3C "ARIA in HTML" specification to the bundled resources directory for offline reference

## Testing
- python -m compileall cortex_browser

------
https://chatgpt.com/codex/tasks/task_e_68ce16e14784832899e359e8c83085ae