### PR TITLE
Align geolocation handling with secure contexts

### DIFF
--- a/cortex_browser/__init__.py
+++ b/cortex_browser/__init__.py
@@ -1,6 +1,12 @@
 """Cortex Browser package."""
 
-from .app import APP_NAME, BrowserWindow, build_application, main, run
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from .app import APP_NAME, BrowserWindow, build_application, main, run
 
 __all__ = [
     "APP_NAME",
@@ -9,5 +15,15 @@ __all__ = [
     "main",
     "run",
 ]
+
+
+def __getattr__(name: str):  # pragma: no cover - trivial delegation
+    if name in __all__:
+        module = import_module(".app", __name__)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(name)  # pragma: no cover - behaviour mirrors default
+
 
 __version__ = "0.1.0"

--- a/cortex_browser/app.py
+++ b/cortex_browser/app.py
@@ -21,6 +21,8 @@ from PySide6.QtWidgets import (
 from PySide6.QtWebEngineCore import QWebEnginePage
 from PySide6.QtWebEngineWidgets import QWebEngineView
 
+from .geolocation import is_secure_geolocation_origin
+
 
 APP_NAME = "Cortex Browser"
 DEFAULT_HOME_PAGE = Path(__file__).resolve().parent / "resources" / "home.html"
@@ -219,7 +221,7 @@ class BrowserWindow(QMainWindow):
 
         if not self._is_secure_geolocation_origin(security_origin):
             self.status_bar.showMessage(
-                "Blocked location request: insecure context", 5000
+                "Blocked location request: origin must use HTTPS or localhost", 5000
             )
             self.web_view.page().setFeaturePermission(
                 security_origin, feature, QWebEnginePage.PermissionPolicy.PermissionDeniedByUser
@@ -270,13 +272,9 @@ class BrowserWindow(QMainWindow):
 
     @staticmethod
     def _is_secure_geolocation_origin(url: QUrl) -> bool:
-        if url.scheme() in {"https", "wss", "file"}:
-            return True
+        """Determine if *url* is a potentially trustworthy origin for geolocation."""
 
-        if url.scheme() == "http" and url.host() in {"localhost", "127.0.0.1", "::1"}:
-            return True
-
-        return False
+        return is_secure_geolocation_origin(url)
 
     def show_about_dialog(self) -> None:
         QMessageBox.about(

--- a/cortex_browser/geolocation.py
+++ b/cortex_browser/geolocation.py
@@ -1,0 +1,40 @@
+"""Helpers for enforcing modern geolocation security requirements."""
+
+from __future__ import annotations
+
+from ipaddress import ip_address
+
+from PySide6.QtCore import QUrl
+
+
+def is_secure_geolocation_origin(url: QUrl) -> bool:
+    """Return ``True`` if *url* qualifies as a secure geolocation origin."""
+
+    scheme = url.scheme().lower()
+
+    if url.isLocalFile() or scheme in {"https", "wss"}:
+        return True
+
+    if scheme in {"blob", "filesystem"}:
+        inner_url = QUrl(url.path())
+        if inner_url.isValid() and inner_url != url:
+            return is_secure_geolocation_origin(inner_url)
+        return False
+
+    if scheme == "http":
+        host = url.host().lower()
+        if not host:
+            return False
+
+        if host == "localhost" or host.endswith(".localhost"):
+            return True
+
+        try:
+            return ip_address(host).is_loopback
+        except ValueError:
+            return False
+
+    return False
+
+
+__all__ = ["is_secure_geolocation_origin"]

--- a/cortex_browser/tests/test_geolocation_security.py
+++ b/cortex_browser/tests/test_geolocation_security.py
@@ -1,0 +1,57 @@
+"""Tests covering the geolocation origin security checks."""
+
+from __future__ import annotations
+
+import unittest
+
+from PySide6.QtCore import QUrl
+
+from cortex_browser.geolocation import is_secure_geolocation_origin
+
+
+class GeolocationOriginSecurityTests(unittest.TestCase):
+    """Validate the logic enforcing modern geolocation security requirements."""
+
+    def assert_secure(self, url: str) -> None:
+        self.assertTrue(
+            is_secure_geolocation_origin(QUrl(url)),
+            msg=f"Expected secure origin for {url}",
+        )
+
+    def assert_insecure(self, url: str) -> None:
+        self.assertFalse(
+            is_secure_geolocation_origin(QUrl(url)),
+            msg=f"Expected insecure origin for {url}",
+        )
+
+    def test_https_is_secure(self) -> None:
+        self.assert_secure("https://example.com")
+
+    def test_wss_is_secure(self) -> None:
+        self.assert_secure("wss://example.com/socket")
+
+    def test_local_file_is_secure(self) -> None:
+        self.assert_secure("file:///home/user/index.html")
+
+    def test_localhost_variants_are_secure(self) -> None:
+        self.assert_secure("http://localhost")
+        self.assert_secure("http://subdomain.localhost")
+
+    def test_loopback_addresses_are_secure(self) -> None:
+        self.assert_secure("http://127.4.5.6")
+        self.assert_secure("http://[::1]/")
+        self.assert_secure("http://[::ffff:127.0.0.1]/")
+
+    def test_standard_http_origin_is_insecure(self) -> None:
+        self.assert_insecure("http://example.com")
+
+    def test_private_network_address_is_insecure(self) -> None:
+        self.assert_insecure("http://192.168.1.10")
+
+    def test_blob_origin_inherits_security(self) -> None:
+        self.assert_secure("blob:https://example.com/identifier")
+        self.assert_insecure("blob:http://example.com/identifier")
+
+
+if __name__ == "__main__":  # pragma: no cover - direct execution helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated geolocation helper that reflects the latest secure-context rules, including localhost subdomains, loopback IPs, and blob/filesystem wrappers
- update the permission denial message and route BrowserWindow through the new helper
- lazily import heavy Qt modules from the package init and add unit tests for the geolocation-origin checks

## Testing
- python -m unittest discover cortex_browser/tests
- python -m compileall cortex_browser

------
https://chatgpt.com/codex/tasks/task_e_68d065d9d8ec8328b99b0ea046d091a0